### PR TITLE
Feature/fgets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/15 15:37:09 by sanghupa          #+#    #+#              #
-#    Updated: 2023/07/18 14:43:30 by sanghupa         ###   ########.fr        #
+#    Updated: 2023/07/18 16:16:51 by sanghupa         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -15,6 +15,8 @@
 
 CC			= cc
 CFLAGS		= -Wall -Werror -Wextra
+
+RL_LINK		= -lreadline
 
 RM			= rm -f
 
@@ -71,8 +73,8 @@ $(LIBFT):
 			@mv $(LIBFT_PATH) ./
 
 $(NAME):	$(OBJ_NAME) $(LIBFT)
-			@$(CC) $(CFLAGS) -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR)
-#			@$(CC) $(CFLAGS) -fsanitize=address -g -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR)
+			@$(CC) $(CFLAGS) -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
+#			@$(CC) $(CFLAGS) -fsanitize=address -g -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
 
 $(NAME_B):	$(OBJ_NAME_B) $(LIBFT)
 			@$(CC) $(CFLAGS) -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR)

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/18 14:37:27 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/18 16:26:22 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,8 +70,14 @@
 // Prevent Heap mem leak: use addition to char or array
 # define DATA_SIZE	3072
 
+// Limiter for command and tokens
+# define MAX_COMMAND_LEN 100
+# define MAX_TOKENS 10
+
 /* minishell.c */
 
 /* minishell_util.c */
+void	getcmd(char *cmd, int len);
+
 
 #endif

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,12 +6,13 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/18 14:46:42 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/18 16:26:28 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+/*
 static void	print_envp(char *envp[])
 {
 	int	i;
@@ -23,22 +24,20 @@ static void	print_envp(char *envp[])
 		i++;
 	}
 }
+*/
 
 int	isexit(char *cmd)
 {
 	return (ft_strncmp(cmd, "exit", 4) == 0);
 }
 
-#define MAX_COMMAND_LEN 100
-#define MAX_TOKENS 10
-
 // TODO: readcmd()
 // - implement fgets()
 // - implement strcspn()
+// - implement case when `\` appears in cmd 
 int	readcmd(char *cmd)
 {
-	ft_printf("> ");
-	fgets(cmd, MAX_COMMAND_LEN, stdin);
+	getcmd(cmd, MAX_COMMAND_LEN);
 
 	// Remove the newline character from the end
 	cmd[strcspn(cmd, "\n")] = '\0';
@@ -98,7 +97,8 @@ int	main(int argc, char *argv[], char *envp[])
 
 	(void)argc;
 	(void)argv;
-	print_envp(envp);
+	(void)envp;
+	// print_envp(envp);
 	while (1)
 	{
 		// Step 1: Accept user input

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -1,0 +1,22 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   minishell_util.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
+/*   Updated: 2023/07/18 16:26:43 by sanghupa         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	getcmd(char *cmd, int len)
+{
+	char	*command;
+
+	command = readline("> ");
+	ft_strlcpy(cmd, command, len);
+	free(command);
+}


### PR DESCRIPTION
Makefile
- 19: Add linker for readline() which needs <readline/readline.h> header file.
- 76: Edit compiling command to have linker for deadline.

include/minishell.h
- 74-75: Move MACROs for command line limiters from minishell.c file to header file.
- 80: Add referece for new function getcmd().

src/minishell.c
- 32-33: Remove Macros and move to header file.
- 40: Replace fgets() function call, which is unallowed for this project, to new implemented function getcmd().

src/minishell_util.c
- Add new .c file to store some util functions in future.
- Add new function getcmd() replacement of fgets().
   - Use readline to get cmd from the prompt which is user input.
   - Because readline do malloc(3) the data, so do ft_strlcpy() to new char* variable and free the allocated memory from readline.