### PR TITLE
Feat/implement execvp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/15 15:37:09 by sanghupa          #+#    #+#              #
-#    Updated: 2023/07/19 22:53:09 by sanghupa         ###   ########.fr        #
+#    Updated: 2023/07/20 20:15:22 by sanghupa         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -63,6 +63,9 @@ re: fclean all
 
 re_bonus: fclean bonus
 
+dev: $(LIBFT)
+			$(CC) -fsanitize=address -g -o $(NAME:.c=.out) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
+
 # Sub Command
 
 %.o: %.c
@@ -78,7 +81,6 @@ $(NAME):	$(OBJ_NAME) $(LIBFT)
 
 $(NAME_B):	$(OBJ_NAME_B) $(LIBFT)
 			@$(CC) $(CFLAGS) -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR)
-
 
 # Test Code 
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/19 22:52:24 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/20 21:52:17 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,7 +78,7 @@
 
 /* minishell_util.c */
 void	getcmd(char *cmd, int len);
-
+int		isexit(char *cmd);
 
 /**
  * @name ft_strtok

--- a/include/pipex.h
+++ b/include/pipex.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 14:34:19 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/18 14:41:19 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/20 17:07:29 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,7 @@ void	heredoc(char *limiter, int argc);
 /* pipex_util.c */
 char	*find_path(char *cmd, char *envp[]);
 void	ft_error(void);
-void	ft_exec(char *arg, char *envp[]);
+void	ft_exec(char *arg[], char *envp[]);
 void	instruction(void);
 int		get_line(char *line[]);
 

--- a/src/ft_strtok.c
+++ b/src/ft_strtok.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 19:59:27 by minakim           #+#    #+#             */
-/*   Updated: 2023/07/20 14:40:07 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/20 17:28:20 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -137,7 +137,7 @@ char	*ft_strtok(char *str, const char *delim)
 	token = str;
 	str = ft_strpbrk(token, delim);
 	if (str == NULL)
-		ft_strlcpy(olds, "", 2);
+		olds = "";
 	else
 	{
 		*str = '\0';

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/19 23:11:47 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/20 20:26:04 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,21 +26,10 @@ static void	print_envp(char *envp[])
 }
 */
 
-int	isexit(char *cmd)
-{
-	return (ft_strncmp(cmd, "exit", 4) == 0);
-}
-
-// TODO: readcmd()
-// - implement strcspn()
-// - implement case when `\` appears in cmd 
 int	readcmd(char *cmd)
 {
 	getcmd(cmd, MAX_COMMAND_LEN);
-
-	// Remove the newline character from the end
 	cmd[ft_strcspn(cmd, "\n")] = '\0';
-
 	return (ft_strlen(cmd));
 }
 
@@ -61,9 +50,7 @@ int	parsecmd(char *cmd, char *tokens[])
 	return (0);
 }
 
-// TODO: executecmd()
-// - implement execvp()
-void	executecmd(char *tokens[])
+void	executecmd(char *tokens[], char *envp[])
 {
 	pid_t	pid;
 
@@ -76,15 +63,13 @@ void	executecmd(char *tokens[])
 	}
 	else if (pid == 0)
 	{
-		// Child process
 		if (tokens[0] == NULL)
 			exit(EXIT_SUCCESS);
-		execvp(tokens[0], tokens);
+		ft_exec(tokens, envp);
 		perror("Error");
 		ft_putstr_fd("Failed to execute command\n", 2);
 		exit(EXIT_FAILURE);
 	}
-	// Parent process
 	wait(NULL);
 }
 
@@ -122,7 +107,7 @@ int	main(int argc, char *argv[], char *envp[])
 		// to handle various commands.
 		// Check the command token and execute the corresponding action or 
 		// system command using libraries or system calls.
-		executecmd(tokens);
+		executecmd(tokens, envp);
 	}
 	return (0);
 }

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/18 16:26:43 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/20 20:25:57 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,4 +19,9 @@ void	getcmd(char *cmd, int len)
 	command = readline("> ");
 	ft_strlcpy(cmd, command, len);
 	free(command);
+}
+
+int	isexit(char *cmd)
+{
+	return (ft_strncmp(cmd, "exit", 4) == 0);
 }

--- a/src/pipex.c
+++ b/src/pipex.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 14:35:32 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/18 14:40:02 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/20 17:12:24 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ void	child_process(char *argv, char *envp[])
 	{
 		close(fd[0]);
 		dup2(fd[1], STDOUT_FILENO);
-		ft_exec(argv, envp);
+		ft_exec(&argv, envp);
 	}
 	else
 		waiting_child(fd, pid);

--- a/src/pipex_util.c
+++ b/src/pipex_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 14:35:50 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/20 20:26:26 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/21 12:13:31 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,20 +58,13 @@ void	ft_error(void)
 /// @param envp pointer to the environment variables
 void	ft_exec(char *arg[], char *envp[])
 {
-	int		i;
 	char	**cmd;
 	char	*path;
 
-	i = 0;
 	cmd = arg;
 	path = find_path(cmd[0], envp);
 	if (path == NULL)
-	{
-		while (cmd[i] != NULL)
-			free(cmd[i++]);
-		free(cmd);
 		ft_error();
-	}
 	if (execve(path, cmd, envp) == -1)
 		ft_error();
 }

--- a/src/pipex_util.c
+++ b/src/pipex_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 14:35:50 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/18 14:40:47 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/20 20:26:26 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,14 +56,14 @@ void	ft_error(void)
 /// and execute the command with the found path
 /// @param arg argument that contains the command for the path
 /// @param envp pointer to the environment variables
-void	ft_exec(char *arg, char *envp[])
+void	ft_exec(char *arg[], char *envp[])
 {
 	int		i;
 	char	**cmd;
 	char	*path;
 
 	i = 0;
-	cmd = ft_split(arg, ' ');
+	cmd = arg;
 	path = find_path(cmd[0], envp);
 	if (path == NULL)
 	{


### PR DESCRIPTION
Makefile
- Add new command `dev` to compile directly from .c files, for debug purposes.

src/ft_strtok.c
- 140: Remove and replace ft_strlcpy() to set an empty string to the variable 'olds'.

include/pipex.h
- Update prototype reference of ft_exec().

src/pipex.c
- 55: Edit the line to fit with the updated function.

src/pipex_util.c
- 59: Edit the prototype of ft_exec()'s first argument from char *arg to char *arg[] to use the function in minishell.
- 66: Remove and replace ft_split(), which take argument and split with a space, into just copy the argument, because the call from minishell will parse the command into tokens, similar sense to the split of command.
- Remove `int i` variable and lines of code that free() the `char *cmd`, which was malloced data but it is not the data set by malloc anymore.

src/minishell.c
- Move isexit() function to minishell_util.c file.
- Remove comments except the comments in main() function.
- Update executecmd() function to take additional argument char *envp[], because the ft_exec() function need the envp.
- Replace execvp() function call to ft_exec() function which using execve() allowed to use in this project to execute the command.
- Edit the executecmd() call in main().

close #13 