### PR TITLE
Feat/signalcontrol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/15 15:37:09 by sanghupa          #+#    #+#              #
-#    Updated: 2023/07/20 20:15:22 by sanghupa         ###   ########.fr        #
+#    Updated: 2023/07/22 10:24:46 by sanghupa         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -64,7 +64,11 @@ re: fclean all
 re_bonus: fclean bonus
 
 dev: $(LIBFT)
-			$(CC) -fsanitize=address -g -o $(NAME:.c=.out) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
+# 			For 42
+#			$(CC) -fsanitize=address -g -o $(NAME:.c=.out) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
+# 			For MacOS
+			$(CC) -fsanitize=address -g -o $(NAME:.c=.out) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK) -L /usr/local/opt/readline/lib -I /usr/local/opt/readline/include
+
 
 # Sub Command
 
@@ -77,7 +81,7 @@ $(LIBFT):
 
 $(NAME):	$(OBJ_NAME) $(LIBFT)
 #			@$(CC) $(CFLAGS) -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
-			@$(CC) $(CFLAGS) -fsanitize=address -g -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
+			@$(CC) $(CFLAGS) -fsanitize=address -g -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK) -L /usr/local/opt/readline/lib -I /usr/local/opt/readline/include
 
 $(NAME_B):	$(OBJ_NAME_B) $(LIBFT)
 			@$(CC) $(CFLAGS) -o $@ $^ -I $(INC_DIR) -I $(LIBFT_I_DIR)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/15 15:37:09 by sanghupa          #+#    #+#              #
-#    Updated: 2023/07/22 10:24:46 by sanghupa         ###   ########.fr        #
+#    Updated: 2023/07/22 10:53:34 by sanghupa         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -65,9 +65,9 @@ re_bonus: fclean bonus
 
 dev: $(LIBFT)
 # 			For 42
-#			$(CC) -fsanitize=address -g -o $(NAME:.c=.out) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
+#			$(CC) -fsanitize=address -g -o $(NAME) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
 # 			For MacOS
-			$(CC) -fsanitize=address -g -o $(NAME:.c=.out) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK) -L /usr/local/opt/readline/lib -I /usr/local/opt/readline/include
+			$(CC) -fsanitize=address -g -o $(NAME) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK) -L /usr/local/opt/readline/lib -I /usr/local/opt/readline/include
 
 
 # Sub Command

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/20 20:26:04 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/22 10:25:53 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,15 @@ static void	print_envp(char *envp[])
 	}
 }
 */
+
+static void	sighandler(int signal)
+{
+	(void)signal;
+	printf("\n");
+	rl_replace_line("", 0);
+	rl_on_new_line();
+	rl_redisplay();
+}
 
 int	readcmd(char *cmd)
 {
@@ -78,12 +87,13 @@ int	main(int argc, char *argv[], char *envp[])
 	char	cmd[MAX_COMMAND_LEN];
 	char	*tokens[MAX_TOKENS];
 
-	(void)argc;
-	(void)argv;
-	(void)envp;
+	if (argc > 1 && argv)
+		ft_putstr_fd("Invalid arguments. Try ./minishell\n", 2);
 	// print_envp(envp);
 	while (1)
 	{
+		signal(SIGINT, sighandler);
+		signal(SIGQUIT, SIG_IGN);
 		// Step 1: Accept user input
 		// Create an infinite loop that continuously prompts the user for input.
 		readcmd(cmd);

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/20 20:25:57 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/22 10:26:04 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,8 @@ void	getcmd(char *cmd, int len)
 	char	*command;
 
 	command = readline("> ");
+	if (!command)
+		exit(EXIT_SUCCESS);
 	ft_strlcpy(cmd, command, len);
 	free(command);
 }


### PR DESCRIPTION
**Makefile**
- 67-70: Update 'dev' command for 42 computer and MacOS. Because MacOS has minor version for C, thus do not support 'rl_replace_line' function. So have to link and include the function reference from homebrew.
- 84: Apply same link and include to default command for 'make'.
- Need to switch to command for 42 computer before submit!

**src/minishell_util.c**
- 20-21: Add an if-statement to check whether the variable 'command' is NULL or not. Because when there are empty in readline() and ctrl-D pressed, it will input the EOF(end of file) to the input, thus readline() will return NULL to 'command'.
  - Then, the program should exit.
  - But, if there are some strings prior to ctrl-D, it should not exit.

**src/minishell.c**
- 29-37: Add new static void function 'sighandler()' that will work with 'signal()' function supported by <signal.h>.
  - The new function will be called when 'signal()' function receive 'SIGINT', which is ctrl-C,  during the program running.
  - What the new function do is displays a new prompt on a new line, leaving the remained string on and ignore.
- 90-91: Add two lines of code that handle 'argc' and 'argv', which just showing STDERROR message to user.
  - It seems better usage than just (void)argc and (void)argv.
- 95: Call 'signal()' to handle ctrl-C signal.
- 96: Call 'signal()' to handle ctrl-\ signal, so when the signal received then just ignore to react.

close #23 
close #24 
close #25 