### PR TITLE
Feat/readcmd

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -85,17 +85,15 @@ void	getcmd(char *cmd, int len);
 int		isexit(char *cmd);
 
 
-//These functions have been 'briefly' tested.
-//The three functions below, "ft_strpbrk, ft_strspn, and ft_strtok" have
-//connectivity and can be used together.
+/* ft_strtok.c */
 char	*ft_strpbrk(const char *str, const char *delim);
 size_t	ft_strspn(const char *str, const char *delim);
 char	*ft_strtok(char *str, const char *delim);
 
-//ft_strcspn.c
+/* ft_strcspn.c.c */
 size_t	ft_strcspn(const char *str, const char *delim);
 
-//ft_strncpy.c
+/* ft_strncpy.c */
 char *ft_strncpy(char *dest, const char *src, size_t size);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/22 14:04:49 by minakim          ###   ########.fr       */
+/*   Updated: 2023/07/22 14:36:13 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,13 +70,11 @@
 // Prevent Heap mem leak: use addition to char or array
 # define DATA_SIZE	3072
 
-/**
- * @def Limiter for command and tokens
- * @note MAX_COMMAND_LEN
- * if running the following command in the terminal:
- *	$ getconf ARG_MAX
- * result is 2097152 (2MB).
- */
+
+//Limiter for command and tokens
+//MAX_COMMAND_LEN if running the following command in the terminal:
+//$ getconf ARG_MAX
+//result is 2097152 (2MB).
 # define MAX_COMMAND_LEN 100 //2097152
 # define MAX_TOKENS 10
 
@@ -86,19 +84,18 @@
 void	getcmd(char *cmd, int len);
 int		isexit(char *cmd);
 
-/**
- * @note These functions have been 'briefly' tested.
- * The three functions below, "ft_strpbrk, ft_strspn, and ft_strtok" have
- * connectivity and can be used together.
- */
+
+//These functions have been 'briefly' tested.
+//The three functions below, "ft_strpbrk, ft_strspn, and ft_strtok" have
+//connectivity and can be used together.
 char	*ft_strpbrk(const char *str, const char *delim);
 size_t	ft_strspn(const char *str, const char *delim);
 char	*ft_strtok(char *str, const char *delim);
 
-/* ft_strcspn.c */
+//ft_strcspn.c
 size_t	ft_strcspn(const char *str, const char *delim);
 
-/* ft_strncpy */
+//ft_strncpy.c
 char *ft_strncpy(char *dest, const char *src, size_t size);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -90,7 +90,7 @@ char	*ft_strpbrk(const char *str, const char *delim);
 size_t	ft_strspn(const char *str, const char *delim);
 char	*ft_strtok(char *str, const char *delim);
 
-/* ft_strcspn.c.c */
+/* ft_strcspn.c */
 size_t	ft_strcspn(const char *str, const char *delim);
 
 /* ft_strncpy.c */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/20 21:52:17 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/22 14:04:49 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,8 +70,14 @@
 // Prevent Heap mem leak: use addition to char or array
 # define DATA_SIZE	3072
 
-// Limiter for command and tokens
-# define MAX_COMMAND_LEN 100
+/**
+ * @def Limiter for command and tokens
+ * @note MAX_COMMAND_LEN
+ * if running the following command in the terminal:
+ *	$ getconf ARG_MAX
+ * result is 2097152 (2MB).
+ */
+# define MAX_COMMAND_LEN 100 //2097152
 # define MAX_TOKENS 10
 
 /* minishell.c */
@@ -81,7 +87,6 @@ void	getcmd(char *cmd, int len);
 int		isexit(char *cmd);
 
 /**
- * @name ft_strtok
  * @note These functions have been 'briefly' tested.
  * The three functions below, "ft_strpbrk, ft_strspn, and ft_strtok" have
  * connectivity and can be used together.
@@ -92,5 +97,8 @@ char	*ft_strtok(char *str, const char *delim);
 
 /* ft_strcspn.c */
 size_t	ft_strcspn(const char *str, const char *delim);
+
+/* ft_strncpy */
+char *ft_strncpy(char *dest, const char *src, size_t size);
 
 #endif

--- a/src/ft_strcspn.c
+++ b/src/ft_strcspn.c
@@ -6,11 +6,10 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 19:59:27 by minakim           #+#    #+#             */
-/*   Updated: 2023/07/19 23:23:28 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/22 13:46:33 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-// #include "../libft/include/libft.h"
 #include "minishell.h"
 
 /**

--- a/src/ft_strncpy.c
+++ b/src/ft_strncpy.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_strncpy.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: minakim <minakim@student.42berlin.de>      +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/07/22 13:32:42 by minakim           #+#    #+#             */
+/*   Updated: 2023/07/22 14:08:12 by minakim          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+// extension function for mini shell project
+char *ft_strncpy(char *dest, const char *src, size_t size);
+
+char *ft_strncpy(char *dest, const char *src, size_t size)
+{
+	unsigned int	i;
+
+	i = 0;
+	while (src[i] != '\0' && i < size)
+	{
+		dest[i] = src[i];
+		++i;
+	}
+	while (i < size)
+	{
+		dest[i] = '\0';
+		i++;
+	}
+	return (dest);
+}

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/22 14:00:55 by minakim          ###   ########.fr       */
+/*   Updated: 2023/07/22 14:34:45 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,6 @@ static void	sighandler(int signal)
 	rl_on_new_line();
 	rl_redisplay();
 }
-
 
 int	readcmd(char *cmd)
 {

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/20 20:26:04 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/22 14:00:55 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,9 +28,30 @@ static void	print_envp(char *envp[])
 
 int	readcmd(char *cmd)
 {
-	getcmd(cmd, MAX_COMMAND_LEN);
-	cmd[ft_strcspn(cmd, "\n")] = '\0';
-	return (ft_strlen(cmd));
+	char	temp_cmd[MAX_COMMAND_LEN];
+	int		total_len;
+	int		len;
+
+	total_len = 0;
+	while (1)
+	{
+		getcmd(temp_cmd, MAX_COMMAND_LEN);
+		len = (int)ft_strcspn(temp_cmd, "\n");
+		if (len > 0 && temp_cmd[len - 1] == '\\')
+		{
+			temp_cmd[len - 1] = ' ';
+			ft_strncpy(cmd + total_len, temp_cmd, len);
+			total_len += len;
+		}
+		else
+		{
+			ft_strncpy(cmd + total_len, temp_cmd, len + 1);
+			total_len += len + 1;
+			break;
+		}
+	}
+	cmd[total_len - 1] = '\0';
+	return (total_len - 1);
 }
 
 int	parsecmd(char *cmd, char *tokens[])


### PR DESCRIPTION
**src/minishell.c**
- 40-63: Add condition and loop to ensure that the command line has a backslash (\\),
and separate the command line with a newline character (\n) to make it a single-line command.

**src/ft_strncpy.c**
- create a new file and implement strncpy function which can be added in libft.
- This function copies from src the given parameter size and fills it with \0 if the size is greater than src.

**include/minishell.h**
- MAX_COMMAND_LEN
- I wrote down the rationale for setting the maximum length. It's a length that the traditional Linux system tolerates.
