### PR TITLE
fix: Delete line 51 

### DIFF
--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/22 14:34:45 by minakim          ###   ########.fr       */
+/*   Updated: 2023/07/23 13:33:38 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,15 +48,14 @@ int	readcmd(char *cmd)
 		len = (int)ft_strcspn(temp_cmd, "\n");
 		if (len > 0 && temp_cmd[len - 1] == '\\')
 		{
-			temp_cmd[len - 1] = ' ';
-			ft_strncpy(cmd + total_len, temp_cmd, len);
-			total_len += len;
+			ft_strncpy(cmd + total_len, temp_cmd, len - 1);
+			total_len += len - 1;
 		}
 		else
 		{
 			ft_strncpy(cmd + total_len, temp_cmd, len + 1);
 			total_len += len + 1;
-			break;
+			break ;
 		}
 	}
 	cmd[total_len - 1] = '\0';


### PR DESCRIPTION
reference issue #36 

src/minishell.c 
38-62 : now the function concatenates the strings without spaces.

## readcmd
> This function reads commands entered by the user and concatenates them into 'cmd'.If a line ends with '\\', it is treated as a line continuation character. In this case, the function removes the backslash and appends the next line directly after the previous one, without any 'white space' or 'newline' characters.

### (extra) line 51

```c
ft_strncpy(cmd + total_len, temp_cmd, len - 1);
```

- **`cmd + total_len`**: This is the destination of the copy operation. The `+ total_len` part is used to move the pointer `total_len` positions forward from the start of the `cmd` string.
- **`temp_cmd`**: This is the source of the copy operation. Characters are copied from the start of this string.
- **`len - 1`**: This is the number of characters to be copied. The `- 1` is used to avoid copying the backslash('\\') at the end of the line.

I wouldn't normally do this, but since my goal was to reduce the lines, I felt it worked pretty well.



