### PR TITLE
Feat/readcmd 2

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/22 14:36:13 by minakim          ###   ########.fr       */
+/*   Updated: 2023/07/24 13:20:55 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,20 +70,19 @@
 // Prevent Heap mem leak: use addition to char or array
 # define DATA_SIZE	3072
 
+// Limit length of command: 
+/// @note MAX_COMMAND_LEN if running the following command in the terminal:
+/// @note $ getconf ARG_MAX  // result is 2097152 (2MB).
+# define MAX_COMMAND_LEN    2097152
 
-//Limiter for command and tokens
-//MAX_COMMAND_LEN if running the following command in the terminal:
-//$ getconf ARG_MAX
-//result is 2097152 (2MB).
-# define MAX_COMMAND_LEN 100 //2097152
-# define MAX_TOKENS 10
+// Limit number of tokens: ...
+# define MAX_TOKENS         10
 
 /* minishell.c */
 
 /* minishell_util.c */
-void	getcmd(char *cmd, int len);
+void	getcmd(char *cmd, size_t len);
 int		isexit(char *cmd);
-
 
 /* ft_strtok.c */
 char	*ft_strpbrk(const char *str, const char *delim);
@@ -94,6 +93,6 @@ char	*ft_strtok(char *str, const char *delim);
 size_t	ft_strcspn(const char *str, const char *delim);
 
 /* ft_strncpy.c */
-char *ft_strncpy(char *dest, const char *src, size_t size);
+char	*ft_strncpy(char *dest, const char *src, size_t size);
 
 #endif

--- a/src/ft_strncpy.c
+++ b/src/ft_strncpy.c
@@ -3,19 +3,19 @@
 /*                                                        :::      ::::::::   */
 /*   ft_strncpy.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minakim <minakim@student.42berlin.de>      +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/22 13:32:42 by minakim           #+#    #+#             */
-/*   Updated: 2023/07/22 14:08:12 by minakim          ###   ########.fr       */
+/*   Updated: 2023/07/24 13:00:31 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 // extension function for mini shell project
-char *ft_strncpy(char *dest, const char *src, size_t size);
+char	*ft_strncpy(char *dest, const char *src, size_t size);
 
-char *ft_strncpy(char *dest, const char *src, size_t size)
+char	*ft_strncpy(char *dest, const char *src, size_t size)
 {
 	unsigned int	i;
 

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/23 13:33:38 by minakim          ###   ########.fr       */
+/*   Updated: 2023/07/24 13:29:29 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,29 +37,29 @@ static void	sighandler(int signal)
 
 int	readcmd(char *cmd)
 {
-	char	temp_cmd[MAX_COMMAND_LEN];
-	int		total_len;
 	int		len;
+	int		total_len;
+	char	temp_cmd[MAX_COMMAND_LEN];
 
 	total_len = 0;
+	ft_strlcpy(cmd, "", 2);
+	if (*cmd != '\0')
+		exit(EXIT_FAILURE);
+	total_len = ft_strlen(cmd);
 	while (1)
 	{
-		getcmd(temp_cmd, MAX_COMMAND_LEN);
+		getcmd(temp_cmd, 0);
 		len = (int)ft_strcspn(temp_cmd, "\n");
-		if (len > 0 && temp_cmd[len - 1] == '\\')
+		if (len == 0 || temp_cmd[len - 1] != '\\')
 		{
-			ft_strncpy(cmd + total_len, temp_cmd, len - 1);
-			total_len += len - 1;
-		}
-		else
-		{
-			ft_strncpy(cmd + total_len, temp_cmd, len + 1);
-			total_len += len + 1;
+			ft_strlcat(cmd, temp_cmd, ft_strlen(cmd) + len + 1);
 			break ;
 		}
+		ft_strlcat(cmd, temp_cmd, ft_strlen(cmd) + len);
 	}
-	cmd[total_len - 1] = '\0';
-	return (total_len - 1);
+	total_len = ft_strlen(cmd);
+	cmd[total_len] = '\0';
+	return (total_len);
 }
 
 int	parsecmd(char *cmd, char *tokens[])
@@ -74,7 +74,6 @@ int	parsecmd(char *cmd, char *tokens[])
 		tokens[i++] = token;
 		token = ft_strtok(NULL, " ");
 	}
-
 	tokens[i] = NULL;
 	return (0);
 }

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -6,20 +6,23 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/22 10:26:04 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/07/24 13:06:33 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	getcmd(char *cmd, int len)
+void	getcmd(char *cmd, size_t len)
 {
 	char	*command;
 
 	command = readline("> ");
 	if (!command)
 		exit(EXIT_SUCCESS);
-	ft_strlcpy(cmd, command, len);
+	len = ft_strlen(command);
+	if (len > MAX_COMMAND_LEN)
+		ft_putstr_fd("warn: command exceed MAX_COMMAND_LEN\n", 2);
+	ft_strlcpy(cmd, command, len + 1);
 	free(command);
 }
 


### PR DESCRIPTION
Refactor the readcmd(), please have a look!

**minishell.c**
- 40-42: Reorder lines.
- 45-48: Initialize arg 'cmd' into empty null string. And if *cmd (cmd[0]) is not NULL then exit() program. Else, initialize 'total_len' to 0.
- 51: Edit getcmd() to take 0 as second arg.
- 53-59,60-62: Simplify the code logic to process '\' backslash.

**minishell_util.c**
- 15: Change the type of second arg 'len' from 'int' to 'size_t', give more flexibility.
- 22-24: Add a warning phase for user to show when the input command is longer than MAX_COMMAND_LEN.
- 25: Update the line to write on 'cmd' only up to 'len+1' from 'command'.

**minishell.h**
- 73-76: Update 'MAX_COMMAND_LEN' from 100 to value of ARG_MAX.
- 84: Update the prototype of getcmd(), due to the change.
- Fix some norm errors.

**ft_strncpy.c**
- Fix some norm errors.