### PR TITLE
[fix]  `t_env` based on feedback

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/02 11:27:22 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/02 17:38:56 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -232,8 +232,8 @@ t_env	*env_newnode(char *key, char *value);
 t_elst	*env_init(void);
 
 /* src/t_env/env_del */
-int		env_reset_node(t_env *node_to_delete);
-int		env_delone(t_elst *list, t_env *node_to_delete);
+void	env_del(t_env *target);
+void	env_delone(t_elst *lst, t_env *target);
 void	env_dellst(t_elst *lst);
 
 /* src/built-in/ft_echo */

--- a/src/built-in/ft_env.c
+++ b/src/built-in/ft_env.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:11:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/02 11:00:38 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/02 17:51:24 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ t_elst	*env_to_dll(char **envp)
 	i = -1;
 	while (envp[++i])
 	{
-		separator = ft_strpbrk(envp[i], "="); // separator point '=' in envp[i]
+		separator = ft_strpbrk(envp[i], "=");
 		if (separator)
 		{
 			node = env_newnode(ft_substr(envp[i], 0, separator - envp[i]), \
@@ -49,8 +49,9 @@ t_elst	*env_to_dll(char **envp)
 		}
 		else
 		{
-			assert("error handling need here");
+			assert("error handling needed here");
 			env_dellst(lst);
+			return (NULL);
 		}
 	}
 	return (lst);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,24 +6,11 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/02 11:02:30 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/02 18:01:40 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-/*
-static void	print_envp(char *envp[])
-{
-	int	i;
-
-	i = 0;
-	while (envp[i])
-	{
-		ft_printf("envp %d = %s\n", i, envp[i]);
-		i++;
-	}
-}
-*/
 
 static void	sighandler(int signal)
 {
@@ -87,7 +74,6 @@ void	executecmd(char *tokens[], char *envp[])
 int	main(int argc, char *argv[], char *envp[])
 {
 	char	cmd[MAX_COMMAND_LEN];
-	// char	*tokens[MAX_TOKENS];
 	t_deque	*deque;
 	t_elst	*lst;
 
@@ -96,6 +82,7 @@ int	main(int argc, char *argv[], char *envp[])
 		ft_putstr_fd("Invalid arguments. Try ./minishell\n", 2);
 	signal(SIGINT, sighandler);
 	signal(SIGQUIT, SIG_IGN);
+	lst = env_to_dll(envp);
 	while (1)
 	{
 		// Step 1: Accept user input
@@ -110,7 +97,6 @@ int	main(int argc, char *argv[], char *envp[])
 			break ;
 
 		deque = deque_init();
-		lst = env_to_dll(envp);
 		(void)lst;
 
 		// Step 3: Parse the command
@@ -135,5 +121,6 @@ int	main(int argc, char *argv[], char *envp[])
 		sent_delall(&deque->end);
 		deque_del(deque);
 	}
+	env_dellst(lst);
 	return (0);
 }

--- a/src/t_env/env_add.c
+++ b/src/t_env/env_add.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:22:25 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/02 11:18:55 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/02 18:00:36 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,6 +78,15 @@ int	env_addnext(t_elst **lst, t_env **current, t_env **new_node)
 	}
 }
 
+/// @brief Adds or updates a key-value pair in the environment list.
+///
+/// This function searches the list for a given key. If the key is found, it updates
+/// the associated value. If the key is not found, it creates a new node with the
+/// given key-value pair and adds it to the end of the list.
+///
+/// @param lst The environment list to update.
+/// @param key The key to search for or add.
+/// @param value The value to set or update.
 void	env_add_or_update(t_elst *lst, char *key, char *value)
 {
 	t_env	*current;
@@ -94,6 +103,6 @@ void	env_add_or_update(t_elst *lst, char *key, char *value)
 		}
 		current = current->next;
 	}
-	new_node = env_newnode(key, value);
+	new_node = env_newnode(ft_strdup(key), ft_strdup(value));
 	env_addrear(&lst, &new_node);
 }

--- a/src/t_env/env_del.c
+++ b/src/t_env/env_del.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:22:59 by minakim           #+#    #+#             */
-/*   Updated: 2023/08/14 17:15:20 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/02 17:38:05 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,44 +14,53 @@
 #include "../../include/minishell.h"
 #include "../../libft/include/libft.h"
 
-int	env_reset_node(t_env *node_to_delete)
+void	env_del(t_env *target)
 {
-	free(node_to_delete->key);
-	free(node_to_delete->value);
-	node_to_delete->prev = NULL;
-	node_to_delete->next = NULL;
-	return (1);
+	target->prev = NULL;
+	target->next = NULL;
+	free(target->key);
+	free(target->value);
+	free(target);
 }
 
-int	env_delone(t_elst *list, t_env *node_to_delete)
+void	env_delone(t_elst *lst, t_env *target)
 {
-	if (list == NULL || node_to_delete == NULL)
-		return (0);
-	if (list->begin == node_to_delete)
+	if (lst == NULL || target == NULL)
+		return ;
+	if (lst->begin == target)
 	{
-		list->begin = node_to_delete->next;
-		if (list->begin != NULL)
-			list->begin->prev = NULL;
+		lst->begin = target->next;
+		if (lst->begin != NULL)
+			lst->begin->prev = NULL;
 	}
-	if (list->end == node_to_delete)
+	if (lst->end == target)
 	{
-		list->end = node_to_delete->prev;
-		if (list->end != NULL)
-			list->end->next = NULL;
+		lst->end = target->prev;
+		if (lst->end != NULL)
+			lst->end->next = NULL;
 	}
-	if (node_to_delete->next != NULL)
-		node_to_delete->next->prev = node_to_delete->prev;
-	if (node_to_delete->prev != NULL)
-		node_to_delete->prev->next = node_to_delete->next;
-	env_reset_node(node_to_delete);
-	free(node_to_delete);
-	env_updatesize(list, -1);
-	return (1);
+	if (target->next != NULL)
+		target->next->prev = target->prev;
+	if (target->prev != NULL)
+		target->prev->next = target->next;
+	env_del(target);
+	env_updatesize(lst, -1);
+	return ;
 }
 
 void	env_dellst(t_elst *lst)
 {
-	while (lst->end != NULL)
-		env_delone(lst, lst->end);
+	t_env	*current;
+	t_env	*next_node;
+
+	if (!lst)
+		return ;
+	current = lst->begin;
+	while (current != NULL)
+	{
+		next_node = current->next;
+		env_delone(lst ,current);
+		current = next_node;
+	}
 	free(lst);
 }

--- a/src/t_env/env_init.c
+++ b/src/t_env/env_init.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:11:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/08/14 19:44:57 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/02 17:59:22 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,8 @@
 #include "../../include/minishell.h"
 #include "../../libft/include/libft.h"
 
+/// @brief This DLL stores the start and end nodes separately in t_elst lst,
+/// and lst updates size, which is the total number of nodes.
 void	env_updatesize(t_elst *lst, int add)
 {
 	if ((lst)->size < 0)
@@ -21,6 +23,9 @@ void	env_updatesize(t_elst *lst, int add)
 	(lst)->size += add;
 }
 
+/// @note Parameters key and value must be malloc
+/// This DLL function is built on the premise that the key and value will be allocated.
+/// will free both key and value from env_del.
 t_env	*env_newnode(char *key, char *value)
 {
 	t_env	*new;
@@ -30,13 +35,16 @@ t_env	*env_newnode(char *key, char *value)
 	new = ft_memalloc(sizeof(t_env));
 	if (!new)
 		return (NULL);
-	new->key = ft_strdup(key);
-	new->value = ft_strdup(value);
+	new->key = key;
+	new->value = value;
 	new->next = NULL;
 	new->prev = NULL;
 	return (new);
 }
 
+/// @note t_elst lst requires memory allocation
+/// this function is called from the env_to_dll function in src/built-in/ft_env,
+/// and is not used separately.
 t_elst	*env_init(void)
 {
 	t_elst	*data;

--- a/test.c
+++ b/test.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/30 14:15:06 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/02 10:39:21 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/02 17:14:35 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,22 +64,8 @@ size_t	readcmd(char *cmd)
 
 int main(int ac, char **av, char **envp)
 {
-	char cmd[MAX_COMMAND_LEN];
+//	char cmd[MAX_COMMAND_LEN];
 	t_elst *lst = env_to_dll(envp);
-
-	while (1)
-	{
-		printf("minishell> ");
-		readcmd(cmd);
-		printf("cmd: %s\n", cmd);
-		char **test = ft_split(cmd, ' ');
-		int size = 0;
-		while (test[size])
-			size++;
-		printf("Current directory before cd: %s\n", getcwd(NULL, 0));
-		ft_cd(test, size, lst);
-		printf("Current directory after cd: %s\n", getcwd(NULL, 0));
-	}
 	env_dellst(lst);
 	return (0);
 }


### PR DESCRIPTION
With your quick feedback, I was able to fix the fatal error. Thank you so much. The problem was that when I first created the node, I had set it to `malloc` the `key` and `value` with `ft_strdup`, and then used `ft_strdup` and `ft_supstr` again in the env_to_dll. During the node creation phase, I left malloc out completely because it could cause a lot of problems.

However, t_env is a function that was planned with the assumption that the key and value would use malloc, so I added a comment to explain this a bit more.


1. Fixed fatal memory licks in src/t_env, ft_env.c
2. Renamed some functions for consistency with other Data Structure functions.

```c
void	env_del(t_env *target);
void	env_delone(t_elst *lst, t_env *target);
void	env_dellst(t_elst *lst);
```

 3. Added descriptions to key functions.
**I'll add the details as commands to each file.**