### PR TITLE
feat: Update expanding of dallar and tilde for parsecmd

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/02 17:38:56 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/04 12:55:36 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -181,16 +181,6 @@ t_sent	*deque_front(t_deque *deque);
 t_sent	*deque_back(t_deque *deque);
 void	deque_print_all(t_deque *deque);
 
-/* src/parsecmd/parsecmd.c */
-int		parsecmd(char *cmd, t_deque *deque, char *envp[]);
-
-/* src/parsecmd/parsecmd_tokenize.c */
-int		get_margc(char *cmd);
-char	**get_margv(char *cmd, int margc);
-
-/* src/parsecmd/parsecmd_util.c */
-void	expand_dallar(char *cmd, char *envp[]);
-void	expand_tilde(char *cmd, char *envp[]);
 
 // struct t_env
 /// @brief This struct was created with a doubly linked list
@@ -246,5 +236,17 @@ char	**dll_to_envp(t_elst *lst);
 
 /*src/built-in/ft_cd */
 int			ft_cd(char **token, int size/* tokenize result */, t_elst *lst);
+
+
+/* src/parsecmd/parsecmd.c */
+int		check_quotes(char *cmd, int index, int status);
+int		parsecmd(char *cmd, t_deque *deque, t_elst *elst);
+
+/* src/parsecmd/parsecmd_tokenize.c */
+int		get_margc(char *cmd);
+char	**get_margv(char *cmd, int margc);
+
+/* src/parsecmd/parsecmd_util.c */
+void	expand_cmd(char *cmd, t_elst *elst);
 
 #endif

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/02 18:01:40 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/04 12:56:37 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ size_t	readcmd(char *cmd)
 	char	temp_cmd[MAX_COMMAND_LEN];
 
 	total_len = 0;
-	ft_strlcpy(cmd, "", 2);
+	ft_bzero(cmd, MAX_COMMAND_LEN);
 	if (*cmd != '\0')
 		exit(EXIT_FAILURE);
 	total_len = ft_strlen(cmd);
@@ -97,14 +97,13 @@ int	main(int argc, char *argv[], char *envp[])
 			break ;
 
 		deque = deque_init();
-		(void)lst;
 
 		// Step 3: Parse the command
 		// Split the user input into individual tokens (commands and arguments) 
 		// using whitespace as a delimiter.
 		// The first token represents the command, 
 		// and subsequent tokens are arguments.
-		parsecmd(cmd, deque, envp);
+		parsecmd(cmd, deque, lst);
 
 		ft_printf("\n");
 		sent_print(&deque->end);

--- a/src/parsecmd/parsecmd.c
+++ b/src/parsecmd/parsecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/03 12:38:54 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/01 16:28:46 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/04 12:54:57 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,7 +96,7 @@ static int	cmdtosent(int margc, char *margv[], t_deque *deque)
 	return (i);
 }
 
-int	parsecmd(char *cmd, t_deque *deque, char *envp[])
+int	parsecmd(char *cmd, t_deque *deque, t_elst *elst)
 {
 	int		i;
 	int		margc;
@@ -107,8 +107,7 @@ int	parsecmd(char *cmd, t_deque *deque, char *envp[])
 		ft_putstr_fd("error: Invalid quotation\n", 2);
 		return (-1);
 	}
-	expand_dallar(cmd, envp);
-	expand_tilde(cmd, envp);
+	expand_cmd(cmd, elst);
 	margc = get_margc(cmd);
 	margv = get_margv(cmd, margc);
 	cmdtosent(margc, margv, deque);

--- a/src/parsecmd/parsecmd_util.c
+++ b/src/parsecmd/parsecmd_util.c
@@ -6,37 +6,13 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/01 13:03:00 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/02 12:35:19 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/04 12:56:59 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int	append_env(char *str, char *cmd, char *envp[])
-{
-	int		i;
-	int		envpi;
-
-	i = 1;
-	while (ft_isalnum(cmd[i]))
-		i++;
-	i--;
-	envpi = 0;
-	while (envp[envpi])
-	{
-		if ((ft_strncmp(envp[envpi], &cmd[1], i) == 0) && \
-			(envp[envpi][i] == '='))
-		{
-			ft_strlcat(str, &envp[envpi][i + 1], \
-				ft_strlen(str) + ft_strlen(&envp[envpi][i + 1]) + 1);
-			break ;
-		}
-		envpi++;
-	}
-	return (i);
-}
-
-static int	append_env_edit(char *str, char *cmd, t_elst *lst)
+static int	append_env(char *str, char *cmd, t_elst *lst)
 {
 	int		i;
 	t_env	*node;
@@ -50,22 +26,25 @@ static int	append_env_edit(char *str, char *cmd, t_elst *lst)
 	{
 		if (ft_strnequ(node->key, &cmd[1], i))
 		{
-			ft_strlcat(str, node->value, ft_strlen(str) + ft_strlen(node->value) + 1);
+			ft_strlcat(str, node->value, \
+						ft_strlen(str) + ft_strlen(node->value) + 1);
 			break ;
 		}
 		node = node->next;
 	}
+	if (cmd[0] == '~')
+		i = 0;
 	return (i);
 }
 
-void	expand_dallar(char *cmd, char *envp[])
+void	expand_cmd(char *cmd, t_elst *elst)
 {
 	char	str[MAX_COMMAND_LEN];
 	int		i;
 	uint8_t	quote_s;
 	uint8_t	quote_d;
 
-	ft_strlcpy(str, "", 2);
+	ft_bzero(&str[0], MAX_COMMAND_LEN);
 	i = 0;
 	quote_s = 0;
 	quote_d = 0;
@@ -76,61 +55,9 @@ void	expand_dallar(char *cmd, char *envp[])
 		else if (cmd[i] == '\"' && quote_s != 1)
 			quote_d ^= 1;
 		if (cmd[i] == '$' && quote_s != 1)
-			i += append_env(&str[0], &cmd[i], envp);
-		else
-			ft_strlcat(&str[0], &cmd[i], ft_strlen(str) + 2);
-		i++;
-	}
-	ft_strlcpy(cmd, str, ft_strlen(str) + 1);
-	return ;
-}
-
-void	expand_tilde(char *cmd, char *envp[])
-{
-	char	str[MAX_COMMAND_LEN];
-	int		i;
-	uint8_t	quote_s;
-	uint8_t	quote_d;
-
-	ft_strlcpy(str, "", 2);
-	i = 0;
-	quote_s = 0;
-	quote_d = 0;
-	while (cmd[i] != '\0')
-	{
-		if (cmd[i] == '\'' && quote_d != 1)
-			quote_s ^= 1;
-		else if (cmd[i] == '\"' && quote_s != 1)
-			quote_d ^= 1;
-		if (cmd[i] == '~' && quote_s != 1)
-			i += append_env(&str[0], "~HOME", envp);
-		else
-			ft_strlcat(&str[0], &cmd[i], ft_strlen(str) + 2);
-		i++;
-	}
-	ft_strlcpy(cmd, str, ft_strlen(str) + 1);
-	return ;
-}
-
-void	expand_tilde_edit(char *cmd, t_elst *lst)
-{
-	char	str[MAX_COMMAND_LEN];
-	int		i;
-	uint8_t	quote_s;
-	uint8_t	quote_d;
-
-	ft_strlcpy(str, "", 2);
-	i = 0;
-	quote_s = 0;
-	quote_d = 0;
-	while (cmd[i] != '\0')
-	{
-		if (cmd[i] == '\'' && quote_d != 1)
-			quote_s ^= 1;
-		else if (cmd[i] == '\"' && quote_s != 1)
-			quote_d ^= 1;
-		if (cmd[i] == '~' && quote_s != 1)
-			i += append_env_edit(&str[0], "~HOME", lst);
+			i += append_env(&str[0], &cmd[i], elst);
+		else if (cmd[i] == '~' && quote_s != 1)
+			i += append_env(&str[0], "~HOME", elst);
 		else
 			ft_strlcat(&str[0], &cmd[i], ft_strlen(str) + 2);
 		i++;


### PR DESCRIPTION
include/minishell.h
- Move parsecmd() relate functions to bottom of the file, because the functions need t_elst which are env related structs.

src/minishell.c
- 31: Edit cmd initializing line to fix bug and make sure the string value init with zero.
- 100: Remove line of code in non-usage.
- 107: Update a param of parsecmd() for the edit of the function.

src/parsecmd/parsecmd.c
- 99: Update parsecmd() to take t_elst as an arg to process env vals.
- 110: Aggregate the expand functions for dallar and tilde sign into one function, call expand_cmd().

src/parsecmd/parsecmd_util.c
- 35-36: In append_env(), add if-statement for expanding tilde character to process tilde during parsing.
- 58-60: In expand_cmd(), add if-statements to process dallar and tilde characters.

Closes #14 , closes #15 , closes #22 , closes #38 , closes #48