### PR TITLE
Feat/prepare parsecmd+pipe

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/04 12:55:36 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 12:52:41 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -83,9 +83,16 @@
 # define TRUE 1
 # define FALSE 0
 
-#define DIR_CHANGE_SUCCESS 0
-#define ERR_DIR_NOT_FOUND -1
-#define ERR_INVALID_PATH -2
+# define DIR_CHANGE_SUCCESS 0
+# define ERR_DIR_NOT_FOUND -1
+# define ERR_INVALID_PATH -2
+
+// STDIN_FILENO == 0
+// STDOUT_FILENO == 1
+// STDERR_FILENO == 2
+# define PIPE_FLAG 3
+# define REDI_FLAG 4
+# define HDOC_FLAG 5
 
 /* minishell.c */
 
@@ -120,8 +127,10 @@ typedef struct s_sent
 	char			*p_unit;
 	int				tokens_len;
 	char			**tokens;
-	int				is_redir;
-	int				is_pipe;
+	int				input_flag;
+	int				output_flag;
+	char			*input_argv;
+	char			*output_argv;
 	struct s_sent	*prev;
 	struct s_sent	*next;
 }				t_sent;
@@ -181,7 +190,6 @@ t_sent	*deque_front(t_deque *deque);
 t_sent	*deque_back(t_deque *deque);
 void	deque_print_all(t_deque *deque);
 
-
 // struct t_env
 /// @brief This struct was created with a doubly linked list
 /// but can work like a deque.
@@ -235,11 +243,9 @@ char	*pathjoin(t_env *node);
 char	**dll_to_envp(t_elst *lst);
 
 /*src/built-in/ft_cd */
-int			ft_cd(char **token, int size/* tokenize result */, t_elst *lst);
-
+int		ft_cd(char **token, int size/* tokenize result */, t_elst *lst);
 
 /* src/parsecmd/parsecmd.c */
-int		check_quotes(char *cmd, int index, int status);
 int		parsecmd(char *cmd, t_deque *deque, t_elst *elst);
 
 /* src/parsecmd/parsecmd_tokenize.c */
@@ -247,6 +253,7 @@ int		get_margc(char *cmd);
 char	**get_margv(char *cmd, int margc);
 
 /* src/parsecmd/parsecmd_util.c */
+int		check_quotes(char *cmd, int index, int status);
 void	expand_cmd(char *cmd, t_elst *elst);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/07 12:52:41 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 17:39:01 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,13 +91,15 @@
 // STDOUT_FILENO == 1
 // STDERR_FILENO == 2
 # define PIPE_FLAG 3
-# define REDI_FLAG 4
-# define HDOC_FLAG 5
+# define REDI_WR_APPEND_FLAG 4
+# define REDI_WR_TRUNC_FLAG 5
+# define REDI_RD_FLAG 6
+# define HDOC_FLAG 7
 
 /* minishell.c */
 
 /* minishell_util.c */
-void	getcmd(char *cmd, size_t len);
+void	getcmd(char *cmd, size_t len, int debug_mode);
 int		isexit(char *cmd);
 
 /* src/util/ */
@@ -246,7 +248,7 @@ char	**dll_to_envp(t_elst *lst);
 int		ft_cd(char **token, int size/* tokenize result */, t_elst *lst);
 
 /* src/parsecmd/parsecmd.c */
-int		parsecmd(char *cmd, t_deque *deque, t_elst *elst);
+int		parsecmd(char *cmd, t_deque *deque, t_elst *elst, int debug_mode);
 
 /* src/parsecmd/parsecmd_tokenize.c */
 int		get_margc(char *cmd);

--- a/src/deque/deque_delete.c
+++ b/src/deque/deque_delete.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 17:39:17 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/08/02 11:58:34 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 22:22:06 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,8 +33,6 @@ t_sent	*deque_pop_front(t_deque *deque)
 		deque->end = NULL;
 	else
 		deque->begin->next = NULL;
-	target->prev = NULL;
-	target->next = NULL;
 	deque->size--;
 	return (target);
 }
@@ -51,8 +49,6 @@ t_sent	*deque_pop_back(t_deque *deque)
 		deque->begin = NULL;
 	else
 		deque->end->prev = NULL;
-	target->prev = NULL;
-	target->next = NULL;
 	deque->size--;
 	return (target);
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/07 22:37:53 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 22:50:43 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,7 +73,6 @@ void	executecmd(char *tokens[], char *envp[])
 
 static void	looper(char *cmd, char *envp[], t_elst *lst, int debug_mode)
 {
-	int		i;
 	t_sent	*sent;
 	t_deque	*deque;
 
@@ -89,7 +88,6 @@ static void	looper(char *cmd, char *envp[], t_elst *lst, int debug_mode)
 		ft_printf("------ result ------\n");
 	}
 
-	i = -1;
 	while (0 < deque->size)
 		executecmd(deque_pop_back(deque)->tokens, envp);
 	sent_delall(&sent);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/04 12:56:37 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 22:37:53 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ static void	sighandler(int signal)
 	rl_redisplay();
 }
 
-size_t	readcmd(char *cmd)
+size_t	readcmd(char *cmd, int debug_mode)
 {
 	size_t	len;
 	size_t	total_len;
@@ -34,7 +34,7 @@ size_t	readcmd(char *cmd)
 	total_len = ft_strlen(cmd);
 	while (1)
 	{
-		getcmd(temp_cmd, 0);
+		getcmd(temp_cmd, 0, debug_mode);
 		len = ft_strcspn(temp_cmd, "\n");
 		if (len == 0 || temp_cmd[len - 1] != '\\')
 		{
@@ -71,54 +71,55 @@ void	executecmd(char *tokens[], char *envp[])
 	wait(NULL);
 }
 
+static void	looper(char *cmd, char *envp[], t_elst *lst, int debug_mode)
+{
+	int		i;
+	t_sent	*sent;
+	t_deque	*deque;
+
+	deque = deque_init();
+	parsecmd(cmd, deque, lst, debug_mode);
+	sent = deque->end;
+
+	if (debug_mode)
+	{
+		ft_printf("\n");
+		sent_print(&sent);
+		ft_printf("\n");
+		ft_printf("------ result ------\n");
+	}
+
+	i = -1;
+	while (0 < deque->size)
+		executecmd(deque_pop_back(deque)->tokens, envp);
+	sent_delall(&sent);
+	deque_del(deque);
+	return ;
+}
+
 int	main(int argc, char *argv[], char *envp[])
 {
+	int		debug_mode;
 	char	cmd[MAX_COMMAND_LEN];
-	t_deque	*deque;
 	t_elst	*lst;
 
-	(void)envp;
-	if (argc > 1 && argv)
+	debug_mode = FALSE;
+	if (ft_strequ(argv[1], "--debug") || ft_strequ(argv[1], "-d"))
+		debug_mode = TRUE;
+	else if (argc > 1 && argv)
+	{
 		ft_putstr_fd("Invalid arguments. Try ./minishell\n", 2);
+		return (0);
+	}
 	signal(SIGINT, sighandler);
 	signal(SIGQUIT, SIG_IGN);
 	lst = env_to_dll(envp);
 	while (1)
 	{
-		// Step 1: Accept user input
-		// Create an infinite loop that continuously prompts the user for input.
-		readcmd(cmd);
-
-		// Step 2: Handle exit condition
-		// Define an exit condition for the shell, such as typing "exit" 
-		// or pressing a specific key combination.
-		// Break the loop and exit the shell when the exit condition is met.
+		readcmd(cmd, debug_mode);
 		if (isexit(cmd))
 			break ;
-
-		deque = deque_init();
-
-		// Step 3: Parse the command
-		// Split the user input into individual tokens (commands and arguments) 
-		// using whitespace as a delimiter.
-		// The first token represents the command, 
-		// and subsequent tokens are arguments.
-		parsecmd(cmd, deque, lst);
-
-		ft_printf("\n");
-		sent_print(&deque->end);
-		ft_printf("\n");
-		deque_print_all(deque);
-
-		// Step 4: Execute the command
-		// Implement a function or a series of conditional statements 
-		// to handle various commands.
-		// Check the command token and execute the corresponding action or 
-		// system command using libraries or system calls.
-		// executecmd(tokens, envp);
-
-		sent_delall(&deque->end);
-		deque_del(deque);
+		looper(cmd, envp, lst, debug_mode);
 	}
 	env_dellst(lst);
 	return (0);

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -6,17 +6,20 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/07/29 14:13:18 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 17:24:40 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	getcmd(char *cmd, size_t len)
+void	getcmd(char *cmd, size_t len, int debug_mode)
 {
 	char	*command;
 
-	command = readline("> ");
+	if (debug_mode)
+		command = readline("미쉘(debug)> ");
+	else
+		command = readline("미쉘> ");
 	if (!command)
 	{
 		ft_putstr_fd("exit\n", STDOUT_FILENO);

--- a/src/parsecmd/parsecmd.c
+++ b/src/parsecmd/parsecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/03 12:38:54 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/07 13:26:09 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 17:41:22 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,13 +28,55 @@ static char	*get_punit(char *margv[], int select, int i)
 	return (ft_strdup(punit));
 }
 
+static void	handle_redirect(t_sent *node, char *margv[], int tmp)
+{
+	if (ft_strequ(margv[tmp], "<"))
+	{
+		node->input_flag = REDI_RD_FLAG;
+		node->input_argv = ft_strdup(margv[tmp + 1]);
+	}
+	else if (ft_strequ(margv[tmp], ">"))
+	{
+		node->output_flag = REDI_WR_TRUNC_FLAG;
+		node->output_argv = ft_strdup(margv[tmp + 1]);
+	}
+	else if (ft_strequ(margv[tmp], ">>"))
+	{
+		node->output_flag = REDI_WR_APPEND_FLAG;
+		node->output_argv = ft_strdup(margv[tmp + 1]);
+	}
+	return ;
+}
+
 static int	split_cmd(t_sent *node, char *margv[], int select, int i)
 {
 	int	tmp;
 
+	tmp = select;
+	while (tmp < i)
+	{
+		// if (ft_strequ(margv[tmp], "<"))
+		// {
+		// 	select += 2;
+		// 	node->input_flag = REDI_RD_FLAG;
+		// 	node->input_argv = ft_strdup(margv[tmp + 1]);
+		// }
+		// else if (ft_strequ(margv[tmp], ">"))
+		// {
+		// 	i -= i - tmp;
+		// 	node->output_flag = REDI_WR_TRUNC_FLAG;
+		// 	node->output_argv = ft_strdup(margv[tmp + 1]);
+		// }
+		// else if (ft_strequ(margv[tmp], ">>"))
+		// {
+		// 	i -= i - tmp;
+		// 	node->output_flag = REDI_WR_APPEND_FLAG;
+		// 	node->output_argv = ft_strdup(margv[tmp + 1]);
+		// }
+		handle_redirect(node, margv, tmp);
+		tmp++;
+	}
 	tmp = 0;
-	// check for redirection or heredoc
-	// process arg `select`
 	node->tokens_len = i - select;
 	node->tokens = (char **)ft_memalloc(sizeof(char *) * (i - select) + 1);
 	while (select < i)
@@ -71,7 +113,7 @@ static int	cmdtosent(int margc, char *margv[], t_deque *deque)
 	return (i);
 }
 
-int	parsecmd(char *cmd, t_deque *deque, t_elst *elst)
+int	parsecmd(char *cmd, t_deque *deque, t_elst *elst, int debug_mode)
 {
 	int		i;
 	int		margc;
@@ -86,15 +128,16 @@ int	parsecmd(char *cmd, t_deque *deque, t_elst *elst)
 	margc = get_margc(cmd);
 	margv = get_margv(cmd, margc);
 	cmdtosent(margc, margv, deque);
-
-	ft_printf("margc: %d\n", margc);
+	if (debug_mode)
+	{
+		i = 0;
+		while (margv[i] != NULL)
+			ft_printf("[%s] ", margv[i++]);
+		ft_printf("\n");
+	}
 	i = 0;
 	while (margv[i] != NULL)
-	{
-		ft_printf("[%s] ", margv[i]);
 		free(margv[i++]);
-	}
 	free(margv);
-	ft_printf("\n");
 	return (0);
 }

--- a/src/parsecmd/parsecmd_util.c
+++ b/src/parsecmd/parsecmd_util.c
@@ -6,11 +6,41 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/01 13:03:00 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/04 12:56:59 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 12:52:21 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+
+int	check_quotes(char *cmd, int index, int status)
+{
+	int	i;
+
+	i = index;
+	while (cmd[++i] != '\0')
+	{
+		if (status == 0)
+		{
+			if (cmd[i] == '\'')
+				i = check_quotes(cmd, i, '\'');
+			else if (cmd[i] == '\"')
+				i = check_quotes(cmd, i, '\"');
+			if (i == -1)
+				return (1);
+			continue ;
+		}
+		if ((status == '\'') && (cmd[i] == '\''))
+			return (i);
+		if ((status == '\"') && (cmd[i] == '\"'))
+			return (i);
+		if (cmd[i + 1] == '\0')
+			return (-1);
+	}
+	if ((status == '\'') || (status == '\"'))
+		return (-1);
+	return (0);
+}
 
 static int	append_env(char *str, char *cmd, t_elst *lst)
 {

--- a/src/t_sent/sent_create.c
+++ b/src/t_sent/sent_create.c
@@ -6,15 +6,15 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 16:07:12 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/08/30 16:47:24 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 12:53:44 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-t_sent	*sent_new(char *p_unit, int is_redir, int is_pipe);
+t_sent	*sent_new(char *p_unit, int input_flag, int output_flag);
 
-t_sent	*sent_new(char *p_unit, int is_redir, int is_pipe)
+t_sent	*sent_new(char *p_unit, int input_flag, int output_flag)
 {
 	t_sent	*this;
 
@@ -24,8 +24,10 @@ t_sent	*sent_new(char *p_unit, int is_redir, int is_pipe)
 	this->p_unit = p_unit;
 	this->tokens_len = 0;
 	this->tokens = NULL;
-	this->is_redir = is_redir;
-	this->is_pipe = is_pipe;
+	this->input_flag = input_flag;
+	this->output_flag = output_flag;
+	this->input_argv = NULL;
+	this->output_argv = NULL;
 	this->prev = NULL;
 	this->next = NULL;
 	return (this);

--- a/src/t_sent/sent_delete.c
+++ b/src/t_sent/sent_delete.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 16:07:48 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/08/04 12:18:38 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 15:31:44 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,11 @@ void	sent_del(t_sent *sent)
 	sent->next = NULL;
 	while (i < sent->tokens_len)
 		free(sent->tokens[i++]);
+	if (sent->input_flag == REDI_RD_FLAG)
+		free(sent->input_argv);
+	if ((sent->output_flag == REDI_WR_TRUNC_FLAG) || \
+		(sent->output_flag == REDI_WR_APPEND_FLAG))
+		free(sent->output_argv);
 	free(sent->tokens);
 	free(sent->p_unit);
 	free(sent);

--- a/src/t_sent/sent_util.c
+++ b/src/t_sent/sent_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 16:07:55 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/08/07 10:27:37 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/07 13:48:42 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,8 @@ void	sent_print(t_sent *sent[])
 	{
 		j = -1;
 		ft_printf("p_unit: [%s]\n", node->p_unit);
+		ft_printf("input: %d, %s\n", node->input_flag, node->input_argv);
+		ft_printf("output: %d, %s\n", node->output_flag, node->output_argv);
 		while (++j < node->tokens_len)
 			ft_printf("[%d: %s] ", j, node->tokens[j]);
 		ft_printf("\n");


### PR DESCRIPTION
- Preparing `parsecmd` to work with pipe and redirections.
- Add debug_mode for convenience of development.
- Uncommented `executecmd()` to test out how `parsecmd` work along with execution.

Once this PR is merged, I am planning to handle pipes and redirections at the execution stage.
- Note) `make test` build fails due to modifying the parameters of some functions, resulting in check fail.

---
- parsecmd 과정에서 파이프와 리다이렉션을 스트럭트에 처리할 수 있도록 기능을 추가했습니다.
- 개발의 편리성을 위해 디버그모드를 추가했습니다.
- executecmd() 의 주석을 풀고 토큰화된 노드의 실행을 테스트 했습니다.

이번 PR이 머지되면 파이프와 리다이렉션은 execution 단에서 처리하도록 추진해볼 예정입니다.
- 참고) 몇몇 함수의 전달인자를 수정하여서 `make test` build 를 실패해서 check fail 이 있습니다. 