### PR TITLE
Feat/built-in (cd ,echo, env, pwd | working on)

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/04 12:55:36 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/04 16:45:43 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,7 +85,7 @@
 
 #define DIR_CHANGE_SUCCESS 0
 #define ERR_DIR_NOT_FOUND -1
-#define ERR_INVALID_PATH -2
+
 
 /* minishell.c */
 
@@ -203,11 +203,14 @@ typedef struct s_env
 /// @note For convenience, unify the internal parameter names as other.
 /// @param begin front node
 /// @param end rear node
+/// @var g_exit adding it here
+/// because the global variables have become unavailable.
 typedef struct s_elst
 {
 	t_env	*begin;
 	t_env	*end;
 	int		size;
+	int 	g_exit;
 }			t_elst;
 
 /* src/t_env/env_add */
@@ -226,8 +229,20 @@ void	env_del(t_env *target);
 void	env_delone(t_elst *lst, t_env *target);
 void	env_dellst(t_elst *lst);
 
+/* src/t_env/env_util */
+///
+/// @param lst
+/// @param key
+/// @return
+char	*env_getvalue(t_elst *lst, char *key);
+///
+/// @param lst
+/// @param key
+/// @return
+void	env_setexit(t_elst *lst, int status);
+
 /* src/built-in/ft_echo */
-void	ft_echo(t_sent *node);
+void	ft_echo(t_sent *node, t_elst *lst);
 
 /* src/built-in/ft_env */
 t_elst	*env_to_dll(char **envp);
@@ -235,8 +250,8 @@ char	*pathjoin(t_env *node);
 char	**dll_to_envp(t_elst *lst);
 
 /*src/built-in/ft_cd */
-int			ft_cd(char **token, int size/* tokenize result */, t_elst *lst);
-
+/// TODO : change param
+int		ft_cd(char **token, int size/* tokenize result */, t_elst *lst);
 
 /* src/parsecmd/parsecmd.c */
 int		check_quotes(char *cmd, int index, int status);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/06 16:02:44 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/07 17:17:14 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -246,6 +246,7 @@ void	ft_echo(t_sent *node, t_elst *lst);
 
 /* src/built-in/ft_env */
 void	ft_env(t_sent *node, t_elst *lst);
+void	ft_pwd(t_sent *node, t_elst *lst);
 t_elst	*env_to_dll(char **envp);
 char	*pathjoin(t_env *node);
 char	**dll_to_envp(t_elst *lst);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/04 16:45:43 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/06 16:02:44 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -245,13 +245,14 @@ void	env_setexit(t_elst *lst, int status);
 void	ft_echo(t_sent *node, t_elst *lst);
 
 /* src/built-in/ft_env */
+void	ft_env(t_sent *node, t_elst *lst);
 t_elst	*env_to_dll(char **envp);
 char	*pathjoin(t_env *node);
 char	**dll_to_envp(t_elst *lst);
 
 /*src/built-in/ft_cd */
 /// TODO : change param
-int		ft_cd(char **token, int size/* tokenize result */, t_elst *lst);
+int		ft_cd(t_sent *node, t_elst *lst);
 
 /* src/parsecmd/parsecmd.c */
 int		check_quotes(char *cmd, int index, int status);

--- a/src/built-in/ft_cd.c
+++ b/src/built-in/ft_cd.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 22:46:27 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/06 16:03:10 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/07 17:21:18 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,6 +95,7 @@ static int change_dir_tilde(char *token, t_elst *lst)
 	return (CD_SUCCESS);
 }
 
+/// FIXME : something now work. test with pwd cmd with linux  :D
 int ft_cd(t_sent *node, t_elst *lst)
 {
 	char	**tokens;
@@ -110,7 +111,7 @@ int ft_cd(t_sent *node, t_elst *lst)
 		ft_printf("cd: too many arguments\n");
 		return (CD_FAILURE);
 	}
-	if (ft_strequ(tokens[1], "-"))
+	if (tokens[1][0] == '-')
 		return (change_dir_oldpwd(lst));
 	if (tokens[1][0] == '~')
 		return (change_dir_tilde(tokens[1], lst));

--- a/src/built-in/ft_cd.c
+++ b/src/built-in/ft_cd.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 22:46:27 by minakim           #+#    #+#             */
-/*   Updated: 2023/08/17 21:38:18 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/05 22:36:45 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,130 +14,107 @@
 #include "../../include/minishell.h"
 #include "../../libft/include/libft.h"
 
+#define CD_SUCCESS 0
+#define CD_FAILURE 1
+
+
+// TODO: need to check what can be error code (i.g. g_exit)
 static int	save_current_dir_as_key(t_elst *lst, char *key)
 {
 	char	pwd[DATA_SIZE];
 
+	ft_bzero(pwd, DATA_SIZE);
+	if (!getcwd(pwd, DATA_SIZE))
+	{
+		perror("getcwd");
+		return (CD_FAILURE);
+	}
 	getcwd(pwd, DATA_SIZE);
 	env_add_or_update(lst, key, pwd);
-	return (0);
+	return (CD_SUCCESS);
 }
 
-static int	change_dir_and_update_oldpwd(char *token /* tokenize result */, t_elst *lst)
+static void update_pwd(t_elst *lst)
 {
-	save_current_dir_as_key(lst, "OLDPWD");
-	if (chdir(token) == ERR_DIR_NOT_FOUND)
+	char	pwd[DATA_SIZE];
+
+	ft_bzero(pwd, DATA_SIZE);
+	getcwd(pwd, DATA_SIZE);
+	env_add_or_update(lst, "PWD", pwd);
+}
+
+static int change_dir_home(t_elst *lst)
+{
+	char	*home_path;
+
+	home_path = env_getvalue(lst, "HOME");
+	if (!home_path || chdir(home_path) == ERR_DIR_NOT_FOUND)
 	{
-		perror("cd");
-		return (ERR_DIR_NOT_FOUND); // return이 꼭 필요할지는 모르겠음.
+		ft_printf("cd: HOME not set or directory not found\n");
+		return (CD_FAILURE);
 	}
-	return (0);
+	return (CD_SUCCESS);
 }
 
-static int	change_dir_from_home_to_target(char *token /* tokenize result */, t_elst *lst)
+static int change_dir_oldpwd(t_elst *lst)
 {
-	char	*path;
-	char 	*home_path;
-	char    full_path[DATA_SIZE];
-	t_env	*node;
+	char	*oldpwd;
 
-	node = lst->begin;
-	while (node)
+	oldpwd = env_getvalue(lst, "OLDPWD");
+	if (!oldpwd || chdir(oldpwd) == ERR_DIR_NOT_FOUND)
 	{
-		if (ft_strequ(node->key, "HOME"))
+		ft_printf("cd: OLDPWD not set or directory not found\n");
+		return (CD_FAILURE);
+	}
+	return (CD_SUCCESS);
+}
+
+static int change_dir_tilde(char *token, t_elst *lst)
+{
+	char	*home_path;
+	char	full_path[DATA_SIZE];
+
+	ft_bzero(full_path, DATA_SIZE);
+	home_path = env_getvalue(lst, "HOME");
+	if (home_path)
+	{
+		ft_strlcpy(full_path, home_path, sizeof(full_path));
+		ft_strlcat(full_path, token + 1, sizeof(full_path));
+
+		if (chdir(full_path) == ERR_DIR_NOT_FOUND)
 		{
-			home_path = node->value;
-			path = ft_strpbrk(token, "~") + 1;
-			ft_strlcpy(full_path, home_path, sizeof(full_path));
-			ft_strlcat(full_path, path, sizeof(full_path));
-			save_current_dir_as_key(lst, "OLDPWD");
-			if (chdir(full_path) == ERR_DIR_NOT_FOUND)
-			{
-				perror("cd");
-				return (ERR_DIR_NOT_FOUND);
-			}
-			return (0);
+			ft_printf("cd: directory not found: %s\n", full_path);
+			return (CD_FAILURE);
 		}
-		node = node->next;
 	}
-	return (0);
-}
-
-static int	change_dir_to_home(t_elst *lst)
-{
-	char 	*home_path;
-	t_env	*node;
-
-	node = lst->begin;
-	while (node)
-	{
-		if (ft_strequ(node->key, "HOME"))
-		{
-			home_path = node->value;
-			save_current_dir_as_key(lst, "OLDPWD");
-			if (chdir(home_path) == ERR_DIR_NOT_FOUND)
-			{
-				perror("cd");
-				return (ERR_DIR_NOT_FOUND);
-			}
-			return (0);
-		}
-		node = node->next;
-	}
-	return (0);
-}
-
-static int	change_dir_to_past_path(t_elst *lst)
-{
-	t_env	*node;
-	char	*path;
-
-	path = NULL;
-	node = lst->begin;
-	while (node)
-	{
-		if (ft_strequ(node->key, "OLDPWD"))
-		{
-			path = node->value;
-			break ;
-		}
-		node = node->next;
-	}
-	if (path == NULL)
-	{
-		fprintf(stderr, "cd: OLDPWD not set\n");
-		return (1);
-	}
-	if (chdir(path) == ERR_DIR_NOT_FOUND)
-	{
-		perror("cd");
-		return (ERR_DIR_NOT_FOUND);
-	}
-	save_current_dir_as_key(lst, "OLDPWD");
-	return (0);
-}
-
-int ft_cd(char **token, int size/* tokenize result */, t_elst *lst)
-{
-	/// cd
-	if (size == 1 && ft_strequ(token[0], "cd"))
-		return (change_dir_to_home(lst));
-	/// cd 123 123 \0
-	if (size == 3)
-		ft_printf("cd: string not in pwd: %s\n", token[1]);
-	/// cd 123 123 123 \0
-	else if (size > 3)
-		ft_printf("cd: too many arguments\n");
-	/// cd -
-	else if (ft_strequ(token[1], "-"))
-		return (change_dir_to_past_path(lst));
-	/// cd ~
-	else if (ft_strequ(token[1], "~"))
-		return (change_dir_to_home(lst));
-	/// cd ~/Desktop
-	else if (ft_strequ(token[1], "~/"))
-		return (change_dir_from_home_to_target(token[1], lst));
 	else
-		change_dir_and_update_oldpwd(token[1], lst);
-	return (0);
+	{
+		ft_printf("cd: HOME not set\n");
+		return (CD_FAILURE);
+	}
+	return (CD_SUCCESS);
+}
+
+int ft_cd(char **token, int size, t_elst *lst)
+{
+	save_current_dir_as_key(lst, "OLDPWD");
+	if (size == 1 && ft_strequ(token[0], "cd"))
+		return (change_dir_home(lst));
+	if (size > 3)
+	{
+		ft_printf("cd: too many arguments\n");
+		return (CD_FAILURE);
+	}
+	if (ft_strequ(token[1], "-"))
+		return (change_dir_oldpwd(lst));
+	if (token[1][0] == '~')
+		return (change_dir_tilde(token[1], lst));
+	if (chdir(token[1]) == ERR_DIR_NOT_FOUND)
+	{
+		ft_printf("cd: directory not found: %s\n", token[1]);
+		return (CD_FAILURE);
+	}
+	update_pwd(lst);
+	lst->g_exit = 0;
+	return (CD_SUCCESS);
 }

--- a/src/built-in/ft_cd.c
+++ b/src/built-in/ft_cd.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 22:46:27 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/05 22:36:45 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/06 16:03:10 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -95,23 +95,28 @@ static int change_dir_tilde(char *token, t_elst *lst)
 	return (CD_SUCCESS);
 }
 
-int ft_cd(char **token, int size, t_elst *lst)
+int ft_cd(t_sent *node, t_elst *lst)
 {
+	char	**tokens;
+	int 	size;
+
+	tokens = node->tokens;
+	size = node->tokens_len;
 	save_current_dir_as_key(lst, "OLDPWD");
-	if (size == 1 && ft_strequ(token[0], "cd"))
+	if (size == 1 && ft_strequ(tokens[0], "cd"))
 		return (change_dir_home(lst));
 	if (size > 3)
 	{
 		ft_printf("cd: too many arguments\n");
 		return (CD_FAILURE);
 	}
-	if (ft_strequ(token[1], "-"))
+	if (ft_strequ(tokens[1], "-"))
 		return (change_dir_oldpwd(lst));
-	if (token[1][0] == '~')
-		return (change_dir_tilde(token[1], lst));
-	if (chdir(token[1]) == ERR_DIR_NOT_FOUND)
+	if (tokens[1][0] == '~')
+		return (change_dir_tilde(tokens[1], lst));
+	if (chdir(tokens[1]) == ERR_DIR_NOT_FOUND)
 	{
-		ft_printf("cd: directory not found: %s\n", token[1]);
+		ft_printf("cd: directory not found: %s\n", tokens[1]);
 		return (CD_FAILURE);
 	}
 	update_pwd(lst);

--- a/src/built-in/ft_cd.c
+++ b/src/built-in/ft_cd.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 22:46:27 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/07 17:21:18 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/08 13:54:46 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,6 @@
 #define CD_SUCCESS 0
 #define CD_FAILURE 1
 
-
 // TODO: need to check what can be error code (i.g. g_exit)
 static int	save_current_dir_as_key(t_elst *lst, char *key)
 {
@@ -26,46 +25,11 @@ static int	save_current_dir_as_key(t_elst *lst, char *key)
 	ft_bzero(pwd, DATA_SIZE);
 	if (!getcwd(pwd, DATA_SIZE))
 	{
-		perror("getcwd");
+		perror("getcwd"); // TODO: add overall error check
 		return (CD_FAILURE);
 	}
 	getcwd(pwd, DATA_SIZE);
 	env_add_or_update(lst, key, pwd);
-	return (CD_SUCCESS);
-}
-
-static void update_pwd(t_elst *lst)
-{
-	char	pwd[DATA_SIZE];
-
-	ft_bzero(pwd, DATA_SIZE);
-	getcwd(pwd, DATA_SIZE);
-	env_add_or_update(lst, "PWD", pwd);
-}
-
-static int change_dir_home(t_elst *lst)
-{
-	char	*home_path;
-
-	home_path = env_getvalue(lst, "HOME");
-	if (!home_path || chdir(home_path) == ERR_DIR_NOT_FOUND)
-	{
-		ft_printf("cd: HOME not set or directory not found\n");
-		return (CD_FAILURE);
-	}
-	return (CD_SUCCESS);
-}
-
-static int change_dir_oldpwd(t_elst *lst)
-{
-	char	*oldpwd;
-
-	oldpwd = env_getvalue(lst, "OLDPWD");
-	if (!oldpwd || chdir(oldpwd) == ERR_DIR_NOT_FOUND)
-	{
-		ft_printf("cd: OLDPWD not set or directory not found\n");
-		return (CD_FAILURE);
-	}
 	return (CD_SUCCESS);
 }
 
@@ -76,26 +40,54 @@ static int change_dir_tilde(char *token, t_elst *lst)
 
 	ft_bzero(full_path, DATA_SIZE);
 	home_path = env_getvalue(lst, "HOME");
-	if (home_path)
-	{
-		ft_strlcpy(full_path, home_path, sizeof(full_path));
-		ft_strlcat(full_path, token + 1, sizeof(full_path));
-
-		if (chdir(full_path) == ERR_DIR_NOT_FOUND)
-		{
-			ft_printf("cd: directory not found: %s\n", full_path);
-			return (CD_FAILURE);
-		}
-	}
-	else
+	save_current_dir_as_key(lst, "OLDPWD");
+	if (!home_path)
 	{
 		ft_printf("cd: HOME not set\n");
 		return (CD_FAILURE);
 	}
+	ft_strlcpy(full_path, home_path, sizeof(full_path));
+	ft_strlcat(full_path, token + 1, sizeof(full_path));
+	if (chdir(full_path) == ERR_DIR_NOT_FOUND)
+	{
+		ft_printf("cd: directory not found: %s\n", full_path);
+		return (CD_FAILURE);
+	}
+	else
+		lst->g_exit = 0;
 	return (CD_SUCCESS);
 }
 
-/// FIXME : something now work. test with pwd cmd with linux  :D
+static int	change_dir_key(t_elst *lst, char *key)
+{
+	char	*path;
+
+	path = env_getvalue(lst, key);
+	save_current_dir_as_key(lst, "OLDPWD");
+	if (!path || chdir(path) == ERR_DIR_NOT_FOUND)
+	{
+		ft_printf("cd: directory not found: %s\n", path);
+		return (CD_FAILURE);
+	}
+	else
+		lst->g_exit = 0;
+}
+
+static int	change_dir(t_elst *lst)
+{
+	char	path[DATA_SIZE];
+
+	getcwd(path, DATA_SIZE);
+	save_current_dir_as_key(lst, "OLDPWD");
+	if (chdir(path) == ERR_DIR_NOT_FOUND)
+	{
+		ft_printf("cd: directory not found: %s\n", path);
+		return (CD_FAILURE);
+	}
+	else
+		lst->g_exit = 0;
+}
+
 int ft_cd(t_sent *node, t_elst *lst)
 {
 	char	**tokens;
@@ -103,16 +95,15 @@ int ft_cd(t_sent *node, t_elst *lst)
 
 	tokens = node->tokens;
 	size = node->tokens_len;
-	save_current_dir_as_key(lst, "OLDPWD");
 	if (size == 1 && ft_strequ(tokens[0], "cd"))
-		return (change_dir_home(lst));
+		return (change_dir_key(lst, "HOME"));
 	if (size > 3)
 	{
 		ft_printf("cd: too many arguments\n");
 		return (CD_FAILURE);
 	}
 	if (tokens[1][0] == '-')
-		return (change_dir_oldpwd(lst));
+		return (change_dir_key(lst, "OLDPWD"));
 	if (tokens[1][0] == '~')
 		return (change_dir_tilde(tokens[1], lst));
 	if (chdir(tokens[1]) == ERR_DIR_NOT_FOUND)
@@ -120,7 +111,6 @@ int ft_cd(t_sent *node, t_elst *lst)
 		ft_printf("cd: directory not found: %s\n", tokens[1]);
 		return (CD_FAILURE);
 	}
-	update_pwd(lst);
-	lst->g_exit = 0;
-	return (CD_SUCCESS);
+	else
+		return (change_dir(lst));
 }

--- a/src/built-in/ft_cd.c
+++ b/src/built-in/ft_cd.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 22:46:27 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/08 13:54:46 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/08 17:39:16 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,14 @@
 #define CD_SUCCESS 0
 #define CD_FAILURE 1
 
-// TODO: need to check what can be error code (i.g. g_exit)
+/**
+ * @brief The functions in this file are partially complete, but
+ * 1. the error message output (TODO: to be implemented)
+ * 2. signal passing arguments (TODO: to be implemented)
+ * 3. more condition check test in ft_cd (TODO: to be implemented)
+ * 4. Exit code testing (TODO: to be implemented).
+ * are incomplete. I'll update them as I go along.
+ */
 static int	save_current_dir_as_key(t_elst *lst, char *key)
 {
 	char	pwd[DATA_SIZE];
@@ -25,36 +32,11 @@ static int	save_current_dir_as_key(t_elst *lst, char *key)
 	ft_bzero(pwd, DATA_SIZE);
 	if (!getcwd(pwd, DATA_SIZE))
 	{
-		perror("getcwd"); // TODO: add overall error check
+		perror("getcwd"); // add overall error check
 		return (CD_FAILURE);
 	}
 	getcwd(pwd, DATA_SIZE);
 	env_add_or_update(lst, key, pwd);
-	return (CD_SUCCESS);
-}
-
-static int change_dir_tilde(char *token, t_elst *lst)
-{
-	char	*home_path;
-	char	full_path[DATA_SIZE];
-
-	ft_bzero(full_path, DATA_SIZE);
-	home_path = env_getvalue(lst, "HOME");
-	save_current_dir_as_key(lst, "OLDPWD");
-	if (!home_path)
-	{
-		ft_printf("cd: HOME not set\n");
-		return (CD_FAILURE);
-	}
-	ft_strlcpy(full_path, home_path, sizeof(full_path));
-	ft_strlcat(full_path, token + 1, sizeof(full_path));
-	if (chdir(full_path) == ERR_DIR_NOT_FOUND)
-	{
-		ft_printf("cd: directory not found: %s\n", full_path);
-		return (CD_FAILURE);
-	}
-	else
-		lst->g_exit = 0;
 	return (CD_SUCCESS);
 }
 
@@ -86,6 +68,31 @@ static int	change_dir(t_elst *lst)
 	}
 	else
 		lst->g_exit = 0;
+}
+
+static int change_dir_tilde(char *token, t_elst *lst)
+{
+	char	*home_path;
+	char	full_path[DATA_SIZE];
+
+	ft_bzero(full_path, DATA_SIZE);
+	home_path = env_getvalue(lst, "HOME");
+	save_current_dir_as_key(lst, "OLDPWD");
+	if (!home_path)
+	{
+		ft_printf("cd: HOME not set\n");
+		return (CD_FAILURE);
+	}
+	ft_strlcpy(full_path, home_path, sizeof(full_path));
+	ft_strlcat(full_path, token + 1, sizeof(full_path));
+	if (chdir(full_path) == ERR_DIR_NOT_FOUND)
+	{
+		ft_printf("cd: directory not found: %s\n", full_path);
+		return (CD_FAILURE);
+	}
+	else
+		lst->g_exit = 0;
+	return (CD_SUCCESS);
 }
 
 int ft_cd(t_sent *node, t_elst *lst)

--- a/src/built-in/ft_echo.c
+++ b/src/built-in/ft_echo.c
@@ -86,8 +86,8 @@ int	determine_toklen(int tok_len, char term)
  * 3. File descriptor control (TODO: to be implemented).
  * 4. Exit code testing (TODO: to be implemented).
  *
- * @param[in] node  A structure containing the 'echo' command and its tokens.
- * @param[in] lst   A linked list containing environmental variables.
+ * @param node  A structure containing the 'echo' command and its tokens.
+ * @param lst   A linked list containing environmental variables.
  */
 void	ft_echo(t_sent *node, t_elst *lst)
 {

--- a/src/built-in/ft_echo.c
+++ b/src/built-in/ft_echo.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/03 19:43:37 by minakim           #+#    #+#             */
-/*   Updated: 2023/08/08 13:34:26 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/05 22:42:35 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,43 +14,93 @@
 #include "../../include/minishell.h"
 #include "../../libft/include/libft.h"
 
-/// Accept the first argument as a command and
-/// the second as an option if it exactly matches the option command(-n),
-/// skipping whitespace.
-///Test (bash)
-//$ echo '-n'
-//>
-//
-//$ echo              '-n'
-//>
-//
-//$              echo "-n"
-//>
-//
-//$ echo     1   "-n"
-//> 1 -n
-/// This function was created assuming it was properly parsed.
-/// The first argument(node->tokens[0]) is the echo.
-void	ft_echo(t_sent *node)
+static int echo_flagcheck(const char *str)
+{
+	char	*tmp;
+	while (*str && ft_isspace(*str))
+		str++;
+	if (ft_strnequ(str, "-n", 2))
+	{
+		str += 2;
+		while (*str && *str == 'n')
+			str++;
+	}
+	while (*str && ft_isspace(*str))
+		str++;
+	if (*str == '\0')
+		return (true);
+	return (false);
+}
+
+/// @brief Determines the termination character for the 'echo' command.
+///
+/// This function examines the input string and checks for the presence of the "-n" flag.
+/// If the flag is found, it sets the 'i' parameter to 1, indicating that the 'echo' command
+/// should start from the second token. If the flag is not present, 'i' is set to 0, indicating
+/// that the 'echo' command should start from the first token.
+///
+/// @param[in]  str  The input string to analyze for the "-n" flag.
+/// @param[out] i    A pointer to an integer that will hold the index for token processing.
+/// @return The termination character ('%' or '\n') based on the presence of the "-n" flag.
+char	determine_term(const char *str, int *i)
+{
+	char	term;
+
+	*i = echo_flagcheck(str);
+	if (*i == 1)
+		term = '%';
+	else
+		term = '\n';
+	return (term);
+}
+
+///  Tilde expansion for the home directory (~)
+void	*echo_homepath(t_elst *lst)
+{
+	char	*path;
+
+	path = NULL;
+	path = env_getvalue(lst, "HOME");
+	if (path)
+		ft_putstr_fd(path, 1);
+	else
+		ft_putstr_fd("~", 1);
+}
+
+
+/**
+ * TODO : rewrite
+ * @brief Executes the 'echo' command with enhanced features.
+ *
+ * This function processes the 'echo' command, supporting advanced features:
+ * 1. Tilde expansion for the home directory (~).
+ * 2. Redirection (TODO: to be implemented).
+ * 3. File descriptor control (TODO: to be implemented).
+ * 4. Exit code testing (TODO: to be implemented).
+ *
+ * @param[in] node  A structure containing the 'echo' command and its tokens.
+ * @param[in] lst   A linked list containing environmental variables.
+ */
+void	ft_echo(t_sent *node, t_elst *lst)
 {
 	int		i;
-	char	terminating;
+	char	term;
+	int		fd;
 
-	if (node->tokens[1] == NULL)
-	{
-		ft_putchar_fd('\n', 1);
-		return ;
-	}
-	i = ft_strequ(node->tokens[1], "-n");
-	if (i == TRUE)
-		terminating = '%';
-	else
-		terminating = '\n';
+	i = 0;
+	fd = 1;
+
+	if (node->tokens[1])
+		term = determine_term(node->tokens[1], &i);
 	while (node->tokens[++i] != NULL)
 	{
-		ft_putstr_fd(node->tokens[i], 1);
+		if (ft_strequ(node->tokens[i], "~"))
+			echo_homepath(lst);
+		else
+			ft_putstr_fd(node->tokens[i], fd);
 		if (node->tokens[i + 1] != NULL)
-			ft_putchar_fd(' ', 1);
+			ft_putchar_fd(' ', fd);
 	}
-	ft_putchar_fd(terminating, 1);
+	ft_putchar_fd(term, fd);
+	lst->g_exit = 0;
 }

--- a/src/built-in/ft_echo.c
+++ b/src/built-in/ft_echo.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/03 19:43:37 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/05 22:42:35 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/06 16:35:30 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,8 @@ static int echo_flagcheck(const char *str)
 	while (*str && ft_isspace(*str))
 		str++;
 	if (*str == '\0')
-		return (true);
-	return (false);
+		return (1);
+	return (0);
 }
 
 /// @brief Determines the termination character for the 'echo' command.
@@ -48,7 +48,7 @@ char	determine_term(const char *str, int *i)
 
 	*i = echo_flagcheck(str);
 	if (*i == 1)
-		term = '%';
+		term = '\0';
 	else
 		term = '\n';
 	return (term);
@@ -67,6 +67,14 @@ void	*echo_homepath(t_elst *lst)
 		ft_putstr_fd("~", 1);
 }
 
+int	determine_toklen(int tok_len, char term)
+{
+	if (term == '\n')
+		return (tok_len);
+	if (term == '\0')
+		return (tok_len);
+	return (0);
+}
 
 /**
  * TODO : rewrite
@@ -89,16 +97,15 @@ void	ft_echo(t_sent *node, t_elst *lst)
 
 	i = 0;
 	fd = 1;
-
 	if (node->tokens[1])
 		term = determine_term(node->tokens[1], &i);
-	while (node->tokens[++i] != NULL)
+	while (++i <node->tokens_len && node->tokens[i])
 	{
 		if (ft_strequ(node->tokens[i], "~"))
 			echo_homepath(lst);
 		else
 			ft_putstr_fd(node->tokens[i], fd);
-		if (node->tokens[i + 1] != NULL)
+		if (i + 1  < node->tokens_len && node->tokens[i + 1] != NULL)
 			ft_putchar_fd(' ', fd);
 	}
 	ft_putchar_fd(term, fd);

--- a/src/built-in/ft_echo.c
+++ b/src/built-in/ft_echo.c
@@ -77,17 +77,12 @@ int	determine_toklen(int tok_len, char term)
 }
 
 /**
- * TODO : rewrite
  * @brief Executes the 'echo' command with enhanced features.
- *
  * This function processes the 'echo' command, supporting advanced features:
  * 1. Tilde expansion for the home directory (~).
  * 2. Redirection (TODO: to be implemented).
  * 3. File descriptor control (TODO: to be implemented).
  * 4. Exit code testing (TODO: to be implemented).
- *
- * @param node  A structure containing the 'echo' command and its tokens.
- * @param lst   A linked list containing environmental variables.
  */
 void	ft_echo(t_sent *node, t_elst *lst)
 {

--- a/src/built-in/ft_env.c
+++ b/src/built-in/ft_env.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:11:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/06 17:00:11 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/07 17:17:40 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,9 +68,9 @@ char	*pathjoin(t_env *node)
 	path = ft_memalloc( key_len + 1 + value_len + 1);
 	if (!path)
 		return (NULL);
-	ft_strlcpy(path, node->key, key_len);
-	path[key_len + 1] = '=';
-	ft_strlcpy(path + 1 + key_len, node->value, value_len);
+	ft_strlcpy(path, node->key, key_len + 1);
+	path[key_len] = '=';
+	ft_strlcpy(path + key_len + 1, node->value, value_len + 1);
 	return (path);
 }
 
@@ -97,7 +97,6 @@ char	**dll_to_envp(t_elst *lst)
 	return (envp);
 }
 
-///  수정 필요함.
 void	ft_env(t_sent *node, t_elst *lst)
 {
 
@@ -112,10 +111,25 @@ void	ft_env(t_sent *node, t_elst *lst)
 	{
 		while (env != NULL)
 		{
-			ft_printf("%s", env->key);
-			ft_printf("=%s\n", env->value);
+			path = pathjoin(env);
+			ft_putstr_fd(path, fd);
+			ft_putchar_fd('\n', fd);
+			free(path);
+			path = NULL;
 			env = env->next;
 		}
+	}
+	lst->g_exit = 0;
+}
+
+void	ft_pwd(t_sent *node, t_elst *lst)
+{
+	char	*path;
+	if (node->tokens_len == 1)
+	{
+		path = env_getvalue(lst, "PWD");
+		ft_putstr_fd(path, 1);
+		ft_putchar_fd('\n', 1);
 	}
 	lst->g_exit = 0;
 }

--- a/src/built-in/ft_env.c
+++ b/src/built-in/ft_env.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:11:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/07 17:17:40 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/07 23:33:02 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,6 +57,7 @@ t_elst	*env_to_dll(char **envp)
 	return (lst);
 }
 
+///@brief pathjoin with malloc
 char	*pathjoin(t_env *node)
 {
 	char	*path;
@@ -97,11 +98,25 @@ char	**dll_to_envp(t_elst *lst)
 	return (envp);
 }
 
+///@brief pathjoin with array
+void	pathjoin_print(char *path, t_env *node)
+{
+	size_t	key_len;
+	size_t	value_len;
+
+	key_len = ft_strlen(node->key);
+	value_len = ft_strlen(node->value);
+
+	ft_strlcpy(path, node->key, key_len + 1);
+	path[key_len] = '=';
+	ft_strlcpy(path + key_len + 1, node->value, value_len + 1);
+}
+
 void	ft_env(t_sent *node, t_elst *lst)
 {
 
 	t_env	*env;
-	char	*path;
+	char	path[DATA_SIZE];
 	int		fd;
 
 	fd = 1;
@@ -111,11 +126,8 @@ void	ft_env(t_sent *node, t_elst *lst)
 	{
 		while (env != NULL)
 		{
-			path = pathjoin(env);
-			ft_putstr_fd(path, fd);
-			ft_putchar_fd('\n', fd);
-			free(path);
-			path = NULL;
+			pathjoin_print(path, env);
+			ft_putendl_fd(path, fd);
 			env = env->next;
 		}
 	}

--- a/src/built-in/ft_env.c
+++ b/src/built-in/ft_env.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:11:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/02 17:51:24 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/06 17:00:11 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,11 +65,11 @@ char	*pathjoin(t_env *node)
 
 	key_len = ft_strlen(node->key);
 	value_len = ft_strlen(node->value);
-	path = ft_memalloc( key_len + 1 + value_len + 1); // Allocate memory for "KEY=VALUE\0"
+	path = ft_memalloc( key_len + 1 + value_len + 1);
 	if (!path)
 		return (NULL);
 	ft_strlcpy(path, node->key, key_len);
-	path[key_len] = '=';
+	path[key_len + 1] = '=';
 	ft_strlcpy(path + 1 + key_len, node->value, value_len);
 	return (path);
 }
@@ -97,7 +97,25 @@ char	**dll_to_envp(t_elst *lst)
 	return (envp);
 }
 
-//void	ft_env(t_sent *lst, char **envp)
-//{
-//
-//}
+///  수정 필요함.
+void	ft_env(t_sent *node, t_elst *lst)
+{
+
+	t_env	*env;
+	char	*path;
+	int		fd;
+
+	fd = 1;
+	env = lst->begin;
+
+	if (node->tokens_len == 1)
+	{
+		while (env != NULL)
+		{
+			ft_printf("%s", env->key);
+			ft_printf("=%s\n", env->value);
+			env = env->next;
+		}
+	}
+	lst->g_exit = 0;
+}

--- a/src/built-in/ft_env.c
+++ b/src/built-in/ft_env.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:11:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/07 23:33:02 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/08 17:48:21 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,6 @@
 
 
 /**
- * Temporary message for commits.
- *
  * @brief This function converts the envp array to a Doubly Linked List (DLL).
  * The DLL uses t_env as its node, where the head of envp (i.e., before '=')
  * is stored as 'key' and the value (i.e., after '=') is stored as 'value'.
@@ -57,7 +55,8 @@ t_elst	*env_to_dll(char **envp)
 	return (lst);
 }
 
-///@brief pathjoin with malloc
+/// @brief combines a KEY and a VALUE in the form `KEY=VALUE`.
+/// The function returns a memory-allocated result.
 char	*pathjoin(t_env *node)
 {
 	char	*path;
@@ -98,7 +97,7 @@ char	**dll_to_envp(t_elst *lst)
 	return (envp);
 }
 
-///@brief pathjoin with array
+/// @brief combines a KEY and a VALUE in the form `KEY=VALUE` to @param path
 void	pathjoin_print(char *path, t_env *node)
 {
 	size_t	key_len;
@@ -112,6 +111,11 @@ void	pathjoin_print(char *path, t_env *node)
 	ft_strlcpy(path + key_len + 1, node->value, value_len + 1);
 }
 
+
+/**
+ * @note The functions below work just fine, but they don't use the proper `fd`.
+ * 1. File descriptor control (TODO: to be implemented).
+ */
 void	ft_env(t_sent *node, t_elst *lst)
 {
 
@@ -140,8 +144,7 @@ void	ft_pwd(t_sent *node, t_elst *lst)
 	if (node->tokens_len == 1)
 	{
 		path = env_getvalue(lst, "PWD");
-		ft_putstr_fd(path, 1);
-		ft_putchar_fd('\n', 1);
+		ft_putendl_fd(path, 1);
 	}
 	lst->g_exit = 0;
 }

--- a/src/t_env/env_del.c
+++ b/src/t_env/env_del.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:22:59 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/02 17:38:05 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/04 15:58:02 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,5 +62,6 @@ void	env_dellst(t_elst *lst)
 		env_delone(lst ,current);
 		current = next_node;
 	}
+	lst->g_exit = 0;
 	free(lst);
 }

--- a/src/t_env/env_init.c
+++ b/src/t_env/env_init.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/08 13:11:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/02 17:59:22 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/04 15:57:35 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,5 +53,6 @@ t_elst	*env_init(void)
 	data->begin = NULL;
 	data->end = NULL;
 	data->size = 0;
+	data->g_exit = 0;
 	return (data);
 }

--- a/src/t_env/env_util.c
+++ b/src/t_env/env_util.c
@@ -1,0 +1,35 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_util.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/09/04 16:14:20 by minakim           #+#    #+#             */
+/*   Updated: 2023/09/04 16:45:33 by minakim          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+#include "../../include/minishell.h"
+#include "../../libft/include/libft.h"
+
+
+/// 찾는다면 Value를, 찾지 못한다면 NULL을 반환합니다.
+char	*env_getvalue(t_elst *lst, char *key)
+{
+	t_env	*node = lst->begin;
+
+	while (node)
+	{
+		if (ft_strequ(node->key, key))
+			return (node->value);
+		node = node->next;
+	}
+	return (NULL);
+}
+
+void	env_setexit(t_elst *lst, int status)
+{
+	lst->g_exit = status;
+}

--- a/test.c
+++ b/test.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/05 21:03:20 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/05 21:12:21 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/06 16:03:23 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,23 +60,30 @@ void ft_exec_test(t_deque *deque, t_elst *lst)
 	exit(EXIT_FAILURE);
 }
 
-// built-in functions check
+/// built-in functions check
 static int dispatchcmd(t_deque *deque, t_elst *lst)
 {
-	char	**tokens;
-	int 	tokens_len;
+	t_sent	*target;
 
-	tokens = deque->begin->tokens;
-	tokens_len = deque->begin->tokens_len;
-	if (ft_strequ(tokens[0], "cd"))
+	target = deque->begin;
+	if (ft_strequ(target->tokens[0], "cd"))
 	{
-		ft_cd(tokens, tokens_len, lst);
+		ft_cd(target, lst);
+		return (1);
+	}
+	else if (ft_strequ(target->tokens[0], "echo"))
+	{
+		ft_echo(target, lst);
+		return (1);
+	}
+	else if (ft_strequ(target->tokens[0], "pwd"))
+	{
 		printf("%s\n", env_getvalue(lst, "PWD"));
 		return (1);
 	}
-	else if (ft_strequ(tokens[0], "echo"))
+	else if (ft_strequ(target->tokens[0], "env"))
 	{
-		ft_echo(deque->begin);
+		ft_env(target, lst);
 		return (1);
 	}
 	return (0);

--- a/test.c
+++ b/test.c
@@ -3,36 +3,24 @@
 /*                                                        :::      ::::::::   */
 /*   test.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
+/*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/07/30 14:15:06 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/02 17:14:35 by minakim          ###   ########.fr       */
+/*   Created: 2023/09/05 21:03:20 by minakim           #+#    #+#             */
+/*   Updated: 2023/09/05 21:12:21 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 #include "../../include/minishell.h"
 #include "../../libft/include/libft.h"
-#include <assert.h>
 
-void ft_print_env(t_env *node)
+static void	sighandler(int signal)
 {
-	printf("%s=%s\n", node->key, node->value);
-}
-
-void tmp_print_all(t_elst *lst)
-{
-	t_env *node;
-	int i = -1;
-
-	node = lst->begin;
-	printf("------- start --------\n");
-	while (node != NULL)
-	{
-		ft_print_env(node);
-		node = node->next;
-	}
-	printf("------- done --------\n");
+	(void)signal;
+	printf("\n");
+	rl_replace_line("", 0);
+	rl_on_new_line();
+	rl_redisplay();
 }
 
 size_t	readcmd(char *cmd)
@@ -42,7 +30,7 @@ size_t	readcmd(char *cmd)
 	char	temp_cmd[MAX_COMMAND_LEN];
 
 	total_len = 0;
-	ft_strlcpy(cmd, "", 2);
+	ft_bzero(cmd, MAX_COMMAND_LEN);
 	if (*cmd != '\0')
 		exit(EXIT_FAILURE);
 	total_len = ft_strlen(cmd);
@@ -62,10 +50,112 @@ size_t	readcmd(char *cmd)
 	return (total_len);
 }
 
-int main(int ac, char **av, char **envp)
+void ft_exec_test(t_deque *deque, t_elst *lst)
 {
-//	char cmd[MAX_COMMAND_LEN];
-	t_elst *lst = env_to_dll(envp);
+	char **tokens = deque->begin->tokens;
+
+	execvp(tokens[0], tokens);
+	perror("Error");
+	ft_putstr_fd("Failed to execute command\n", 2);
+	exit(EXIT_FAILURE);
+}
+
+// built-in functions check
+static int dispatchcmd(t_deque *deque, t_elst *lst)
+{
+	char	**tokens;
+	int 	tokens_len;
+
+	tokens = deque->begin->tokens;
+	tokens_len = deque->begin->tokens_len;
+	if (ft_strequ(tokens[0], "cd"))
+	{
+		ft_cd(tokens, tokens_len, lst);
+		printf("%s\n", env_getvalue(lst, "PWD"));
+		return (1);
+	}
+	else if (ft_strequ(tokens[0], "echo"))
+	{
+		ft_echo(deque->begin);
+		return (1);
+	}
+	return (0);
+}
+
+void executecmd(t_deque *deque, t_elst *lst)
+{
+	pid_t   pid;
+
+	if (dispatchcmd(deque, lst))
+		return;
+	pid = fork();
+	if (pid < 0)
+	{
+		perror("Error");
+		ft_putstr_fd("Failed to fork\n", 2);
+		exit(EXIT_FAILURE);
+	}
+	else if (pid == 0)
+	{
+		if (deque->begin == NULL)
+			exit(EXIT_SUCCESS);
+		ft_exec_test(deque, lst);
+		perror("Error");
+		ft_putstr_fd("Failed to execute command\n", 2);
+		exit(EXIT_FAILURE);
+	}
+	wait(NULL);
+}
+
+int	main(int argc, char *argv[], char *envp[])
+{
+	char	cmd[MAX_COMMAND_LEN];
+	t_deque	*deque;
+	t_elst	*lst;
+
+	(void)envp;
+	if (argc > 1 && argv)
+		ft_putstr_fd("Invalid arguments. Try ./minishell\n", 2);
+	signal(SIGINT, sighandler);
+	signal(SIGQUIT, SIG_IGN);
+	lst = env_to_dll(envp);
+	while (1)
+	{
+		// Step 1: Accept user input
+		// Create an infinite loop that continuously prompts the user for input.
+		readcmd(cmd);
+
+		// Step 2: Handle exit condition
+		// Define an exit condition for the shell, such as typing "exit"
+		// or pressing a specific key combination.
+		// Break the loop and exit the shell when the exit condition is met.
+		if (isexit(cmd))
+			break ;
+
+		deque = deque_init();
+
+		// Step 3: Parse the command
+		// Split the user input into individual tokens (commands and arguments)
+		// using whitespace as a delimiter.
+		// The first token represents the command,
+		// and subsequent tokens are arguments.
+		parsecmd(cmd, deque, lst);
+
+//		ft_printf("\n");
+//		sent_print(&deque->end);
+//		ft_printf("\n");
+//		deque_print_all(deque);
+
+		// Step 4: Execute the command
+		// Implement a function or a series of conditional statements
+		// to handle various commands.
+		// Check the command token and execute the corresponding action or
+		// system command using libraries or system calls.
+		executecmd(deque, lst);
+
+		sent_delall(&deque->end);
+		deque_del(deque);
+	}
 	env_dellst(lst);
 	return (0);
 }

--- a/test.c
+++ b/test.c
@@ -6,7 +6,7 @@
 /*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/05 21:03:20 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/06 16:03:23 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/07 17:08:23 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,6 +86,12 @@ static int dispatchcmd(t_deque *deque, t_elst *lst)
 		ft_env(target, lst);
 		return (1);
 	}
+	else if (ft_strequ(target->tokens[0], "env"))
+	{
+		ft_pwd(target, lst);
+		return (1);
+	}
+
 	return (0);
 }
 
@@ -166,3 +172,4 @@ int	main(int argc, char *argv[], char *envp[])
 	env_dellst(lst);
 	return (0);
 }
+


### PR DESCRIPTION
It's not perfect (check out the TODOs in the file), but it's done enough that it can be tested in other functions. I haven't found any leaks yet other than the memory leak caused by `readline`.

---

I'm prototyping all the built-in functions to be the same.

```
void ft_funcname(t_sent *node, t_elst *lst)
```

---

#### 1. minishell.c
```c
typedef struct s_elst
{
	t_env	*begin;
	t_env	*end;
	int		size;
	int 	g_exit;
}			t_elst;
```

as I told you before,  I added `g_exit` in `t_elst`. I really like the idea you're talking about, let's use this argument to connect to the global variable.
 

#### 2. ft_cd.c
It was created by updating the old folder address to a new environment variable called `OLDPWD` and navigating to the required location via a given key. 

#### 3. ft_echo.c

Here are some case where the echo feature should work.
```shell
$ echo (input)
$ echo -n (input)
$ echo -nnnnnnnnnnnnnnnnnnnnnnnnn (input)
```