### PR TITLE
feat: Update executecmd to work with built-in functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/15 15:37:09 by sanghupa          #+#    #+#              #
-#    Updated: 2023/09/01 17:21:07 by sanghupa         ###   ########.fr        #
+#    Updated: 2023/09/12 22:28:01 by sanghupa         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -98,6 +98,7 @@ TMP_LIB_C	= $(shell find ./src/util -iname "*.c")
 TMP_LIB_D	= $(shell find ./src/t_env -iname "*.c")
 TMP_LIB_E	= $(shell find ./src/built-in -iname "*.c")
 TMP_LIB_F	= $(shell find ./src/parsecmd -iname "*.c")
+TMP_LIB_G	= $(shell find ./src/executecmd -iname "*.c")
 
 TMP 		= $(SRC_DIR)/pipex_util.c \
 				$(SRC_DIR)/pipex.c \
@@ -107,7 +108,8 @@ TMP 		= $(SRC_DIR)/pipex_util.c \
 				$(TMP_LIB_C) \
 				$(TMP_LIB_D) \
 				$(TMP_LIB_E) \
-				$(TMP_LIB_F)
+				$(TMP_LIB_F) \
+#				$(TMP_LIB_G)
 #				$(SRC_DIR)/minishell.c \
 
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/10 15:10:21 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/12 21:55:08 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -219,7 +219,7 @@ typedef struct s_elst
 	t_env	*begin;
 	t_env	*end;
 	int		size;
-	int 	g_exit;
+	int		g_exit;
 }			t_elst;
 
 /* src/t_env/env_add */
@@ -238,7 +238,8 @@ void	env_delone(t_elst *lst, t_env *target);
 void	env_dellst(t_elst *lst);
 
 /* src/t_env/env_util */
-int		ft_setenv(t_elst *lst, const char *key, const char *value, int overwrite);
+int		ft_setenv(t_elst *lst, const char *key, \
+					const char *value, int overwrite);
 char	*env_getvalue(t_elst *lst, char *key);
 void	env_setexit(t_elst *lst, int status);
 
@@ -258,8 +259,6 @@ void	ft_cd(t_sent *node, t_elst *lst);
 
 /*src/built-in/ft_export */
 
-
-
 /* src/parsecmd/parsecmd.c */
 int		parsecmd(char *cmd, t_deque *deque, t_elst *elst, int debug_mode);
 
@@ -270,5 +269,8 @@ char	**get_margv(char *cmd, int margc);
 /* src/parsecmd/parsecmd_util.c */
 int		check_quotes(char *cmd, int index, int status);
 void	expand_cmd(char *cmd, t_elst *elst);
+
+/* src/executecmd/executecmd.c */
+void	executecmd(t_deque *deque, t_elst *lst);
 
 #endif

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -1,0 +1,129 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   executecmd.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
+/*   Updated: 2023/09/12 22:38:21 by sanghupa         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/// built-in functions check
+typedef struct s_cmd
+{
+	char	*cmd_name;
+	void	(*cmd_func)(t_sent *node, t_elst *lst);
+}				t_cmd;
+
+static int	dispatchcmd(t_sent *node, t_elst *lst)
+{
+	static t_cmd	cmd_table[] = {
+	{"cd", ft_cd},
+	{"echo", ft_echo},
+	{"pwd", ft_pwd},
+	{"env", ft_env},
+	{NULL, NULL}
+	};
+	int				i;
+
+	i = -1;
+	while (cmd_table[++i].cmd_name)
+	{
+		if (ft_strequ(node->tokens[0], cmd_table[i].cmd_name))
+		{
+			cmd_table[i].cmd_func(node, lst);
+			return (1);
+		}
+	}
+	return (0);
+}
+
+/// TMP FUNCTION.
+static void	free_menvp(char **menvp)
+{
+	int	i;
+
+	i = -1;
+	while (menvp[++i])
+		free(menvp[i]);
+	free(menvp);
+	menvp = NULL;
+}
+
+void	execute_node(t_sent *node, t_elst *lst)
+{
+	pid_t	pid;
+	char	**menvp;
+
+	pid = fork();
+	if (pid < 0)
+	{
+		perror("Error");
+		ft_putstr_fd("Failed to fork\n", 2);
+		exit(EXIT_FAILURE);
+	}
+	else if (pid == 0)
+	{
+		if (node->tokens[0] == NULL)
+			exit(EXIT_SUCCESS);
+		if (dispatchcmd(node, lst))
+			exit(EXIT_SUCCESS);
+		menvp = dll_to_envp(lst);
+		ft_exec(node->tokens, menvp);
+		free_menvp(menvp);
+		perror("Error");
+		ft_putstr_fd("Failed to execute command\n", 2);
+		exit(EXIT_FAILURE);
+	}
+	waitpid(pid, NULL, 0);
+}
+
+void	executecmd(t_deque *deque, t_elst *lst)
+{
+	int		filein;
+	int		fileout;
+	t_sent	*node;
+
+	while (0 < deque->size)
+	{
+		node = deque_pop_back(deque);
+		// TODO: implement execution stage
+		if (node->input_flag == HDOC_FLAG)
+		{
+			// handle input heredoc 
+			execute_node(node, lst);
+		}
+		else if (node->input_flag == REDI_RD_FLAG)
+		{
+			// handle input redirection read
+			execute_node(node, lst);
+		}
+		else if (node->input_flag == PIPE_FLAG)
+		{
+			// handle input pipe
+			execute_node(node, lst);
+		}
+		if (node->output_flag == PIPE_FLAG)
+		{
+			// handle output pipe
+			execute_node(node, lst);
+		}
+		else if (node->output_flag == REDI_WR_APPEND_FLAG)
+		{
+			// handle output redirection write append
+			execute_node(node, lst);
+		}
+		else if (node->output_flag == REDI_WR_TRUNC_FLAG)
+		{
+			// handle output redirection write trunc
+			execute_node(node, lst);
+		}
+		else
+			execute_node(node, lst);
+	}
+	return ;
+}

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/12 21:53:24 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/12 22:46:15 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,7 @@ size_t	readcmd(char *cmd, int debug_mode)
 	return (total_len);
 }
 
-static void	looper(char *cmd, char *envp[], t_elst *lst, int debug_mode)
+static void	looper(char *cmd, t_elst *lst, int debug_mode)
 {
 	t_sent	*sent;
 	t_deque	*deque;
@@ -93,7 +93,7 @@ int	main(int argc, char *argv[], char *envp[])
 		readcmd(cmd, debug_mode);
 		if (isexit(cmd))
 			break ;
-		looper(cmd, envp, lst, debug_mode);
+		looper(cmd, lst, debug_mode);
 	}
 	env_dellst(lst);
 	return (0);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/07 22:50:43 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/12 21:53:24 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,29 +48,6 @@ size_t	readcmd(char *cmd, int debug_mode)
 	return (total_len);
 }
 
-void	executecmd(char *tokens[], char *envp[])
-{
-	pid_t	pid;
-
-	pid = fork();
-	if (pid < 0)
-	{
-		perror("Error");
-		ft_putstr_fd("Failed to fork\n", 2);
-		exit(EXIT_FAILURE);
-	}
-	else if (pid == 0)
-	{
-		if (tokens[0] == NULL)
-			exit(EXIT_SUCCESS);
-		ft_exec(tokens, envp);
-		perror("Error");
-		ft_putstr_fd("Failed to execute command\n", 2);
-		exit(EXIT_FAILURE);
-	}
-	wait(NULL);
-}
-
 static void	looper(char *cmd, char *envp[], t_elst *lst, int debug_mode)
 {
 	t_sent	*sent;
@@ -88,8 +65,7 @@ static void	looper(char *cmd, char *envp[], t_elst *lst, int debug_mode)
 		ft_printf("------ result ------\n");
 	}
 
-	while (0 < deque->size)
-		executecmd(deque_pop_back(deque)->tokens, envp);
+	executecmd(deque, lst);
 	sent_delall(&sent);
 	deque_del(deque);
 	return ;

--- a/test.c
+++ b/test.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   test.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minakim <minakim@student.1337.ma>          +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/05 21:03:20 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/10 15:45:28 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/12 22:26:26 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,14 +91,11 @@ void	free_mevnp(char **menvp)
 	menvp = NULL;
 }
 
-/// I've marked the parts I've edited.
-void	executecmd(t_sent *node, t_elst *lst)
+void	execute_node(t_sent *node, t_elst *lst)
 {
 	pid_t	pid;
 	char	**menvp; // edited
 
-	if (dispatchcmd(node, lst)) // edited
-		return ;
 	pid = fork();
 	if (pid < 0)
 	{
@@ -110,6 +107,8 @@ void	executecmd(t_sent *node, t_elst *lst)
 	{
 		if (node->tokens[0] == NULL)
 			exit(EXIT_SUCCESS);
+		if (dispatchcmd(node, lst)) // edited
+			exit(EXIT_SUCCESS);
 		menvp = dll_to_envp(lst); // edited
 		ft_exec(node->tokens, menvp); // edited
 		free_mevnp(menvp); /// edited
@@ -118,6 +117,19 @@ void	executecmd(t_sent *node, t_elst *lst)
 		exit(EXIT_FAILURE);
 	}
 	wait(NULL);
+}
+
+/// I've marked the parts I've edited.
+void	executecmd(t_deque *deque, t_elst *lst)
+{
+	t_sent	*node;
+
+	while (0 < deque->size)
+	{
+		node = deque_pop_back(deque);
+		execute_node(node, lst);
+	}
+	return ;
 }
 
 static void	looper(char *cmd, t_elst *lst, int debug_mode)
@@ -137,8 +149,7 @@ static void	looper(char *cmd, t_elst *lst, int debug_mode)
 		ft_printf("------ result ------\n");
 	}
 
-	while (0 < deque->size)
-		executecmd(deque_pop_back(deque), lst);
+	executecmd(deque, lst);
 	sent_delall(&sent);
 	deque_del(deque);
 	return ;


### PR DESCRIPTION
Makefile
- 101,112: Add new line to track new directory, src/exeuctecmd.

include/minishell.h
- Fix some norm errors.
- 274: Add new protype for executecmd().

src/minishell.c
- Extract executecmd() to separated file with directory.
- 68: Update looper() function to call executecmd() with new implementation, removing while-loop.

src/executecmd/executecmd.c
- Add new directory and file to manage execute related functions.
- Add new struct t_cmd and new functions dispatchcmd() and free_menvp(), suggested by @miooo0o
- Add new function execute_node() to pass a node and execute the node.
- (ing) Edit function executecmd() to execute with redirection, heredoc and pipe. Still working on it.