### PR TITLE
feat: Fix memory leak from path checking

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/21 15:32:54 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/21 16:43:43 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,7 +105,7 @@
 /* minishell_util.c */
 void	getcmd(char *cmd, size_t len, int debug_mode);
 int		isexit(char *cmd);
-void	ms_error(char *msg);
+int		ms_error(char *msg);
 
 /* src/util/ */
 char	*ft_strpbrk(const char *str, const char *delim);
@@ -308,9 +308,12 @@ void	flag_redi_trunc(t_sent *node, t_elst *lst);
 
 /* src/executecmd/executecmd_util.c */
 void	ft_free_2d(char **targets);
+int		ft_free_check(char *path, char *menvp[], int ret);
 char	*ms_find_path(char *cmd, char *envp[]);
-void	check_path(char *path);
-void	check_pid(pid_t pid);
 void	init_fd(int *fd, int *prev_fd);
+
+/* src/executecmd/executecmd_check.c */
+int		check_path(char *path);
+int		check_pid(pid_t pid);
 
 #endif

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,13 +6,13 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/21 15:43:08 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/21 16:44:01 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
+int		run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
 void	child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
 void	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd);
 
@@ -35,7 +35,7 @@ void	executecmd(t_deque *deque, t_elst *lst)
 	}
 }
 
-void	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
+int	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 {
 	pid_t	pid;
 	char	**menvp;
@@ -43,17 +43,18 @@ void	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 
 	menvp = dll_to_envp(lst);
 	path = ms_find_path(cmd->tokens[0], menvp);
-	check_path(path);
+	if (check_path(path))
+		return (ft_free_check(path, menvp, 1));
 	pid = fork();
-	check_pid(pid);
+	if (check_pid(pid))
+		return (ft_free_check(path, menvp, 1));
 	if (pid == 0)
 	{
 		child_proc(cmd, lst, fd, prev_fd);
 		execute_node(cmd, menvp, path);
 	}
 	parent_proc(pid, cmd, fd, prev_fd);
-	ft_free_2d(menvp);
-	free(path);
+	return (ft_free_check(path, menvp, 0));
 }
 
 void	child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)

--- a/src/executecmd/executecmd_check.c
+++ b/src/executecmd/executecmd_check.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   executecmd_check.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/09/21 16:38:30 by sanghupa          #+#    #+#             */
+/*   Updated: 2023/09/21 16:38:51 by sanghupa         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+int	check_path(char *path)
+{
+	if (path == NULL)
+		return (ms_error("check_path error\n"));
+	return (0);
+}
+
+int	check_pid(pid_t pid)
+{
+	if (pid < 0)
+		return (ms_error("unable to fork\n"));
+	return (0);
+}

--- a/src/executecmd/executecmd_util.c
+++ b/src/executecmd/executecmd_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/17 13:10:51 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/21 15:27:42 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/21 16:42:21 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,13 @@ void	ft_free_2d(char **targets)
 		free(targets[i]);
 	free(targets);
 	targets = NULL;
+}
+
+int	ft_free_check(char *path, char *menvp[], int ret)
+{
+	ft_free_2d(menvp);
+	free(path);
+	return (ret);
 }
 
 char	*ms_find_path(char *cmd, char *envp[])
@@ -50,18 +57,6 @@ char	*ms_find_path(char *cmd, char *envp[])
 	}
 	ft_free_2d(paths);
 	return (0);
-}
-
-void	check_path(char *path)
-{
-	if (path == NULL)
-		ms_error("check_path error\n");
-}
-
-void	check_pid(pid_t pid)
-{
-	if (pid < 0)
-		ms_error("unable to fork\n");
 }
 
 void	init_fd(int *fd, int *prev_fd)

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/21 15:26:29 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/21 16:32:00 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,9 +47,9 @@ int	isexit(char *cmd)
 	return (ret);
 }
 
-void	ms_error(char *msg)
+int	ms_error(char *msg)
 {
 	perror("Error");
 	ft_putstr_fd(msg, 2);
-	return ;
+	return (1);
 }


### PR DESCRIPTION
src/minishell_util.c
- Edit ms_error() to return int 1 for error.

src/executecmd/executecmd.c
- Edit run_process() to return int 1 or 0 depends on the execution.

src/executecmd/executecmd_util.c
- Add new function ft_free_check() to reduce repeat of function call on same variables, like menvp and path, and return int.
- Remove functions check_path() and check_pid() to new file.

src/executecmd/executecmd_check.c
- Move check_path() and check_pid() from executecmd_util.c file.