### PR TITLE
Fix/memoryleak redi+heredoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/07/15 15:37:09 by sanghupa          #+#    #+#              #
-#    Updated: 2023/09/12 22:28:01 by sanghupa         ###   ########.fr        #
+#    Updated: 2023/09/22 15:40:21 by sanghupa         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -65,9 +65,10 @@ re_bonus: fclean bonus
 
 dev: $(LIBFT)
 # 			For 42
+			$(CC) -g -o $(NAME) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
 #			$(CC) -fsanitize=address -g -o $(NAME) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK)
 # 			For MacOS
-			$(CC) -fsanitize=address -g -o $(NAME) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK) -L /usr/local/opt/readline/lib -I /usr/local/opt/readline/include
+#			$(CC) -fsanitize=address -g -o $(NAME) $(SRC_NAME) $^ -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK) -L /usr/local/opt/readline/lib -I /usr/local/opt/readline/include
 #			For dorker exe
 #			gcc -g -o $(NAME) $(SRC_NAME) $^ -Llibft -I $(INC_DIR) -I $(LIBFT_I_DIR) $(RL_LINK) -lft
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/21 16:43:43 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 15:23:56 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -294,17 +294,17 @@ typedef enum e_mode{
 
 /// execute
 /* src/executecmd/executecmd.c */
-void	executecmd(t_deque *deque, t_elst *lst);
-void	execute_node(t_sent *node, char *menvp[], char *path);
-void	run_by_flag(t_sent *cmd, t_elst *lst, t_mode flag);
+int		executecmd(t_deque *deque, t_elst *lst);
+int		execute_node(t_sent *node, char *menvp[], char *path);
+int		run_by_flag(t_sent *cmd, t_elst *lst, t_mode flag);
 int		dispatchcmd(t_sent *node, t_elst *lst);
 /// list of executable flags
 /* src/executecmd/runheredoc.c */
-void	flag_heredoc(t_sent *node, t_elst *lst);
+int		flag_heredoc(t_sent *node, t_elst *lst);
 /* src/executecmd/runredi.c */
-void	flag_redi_read(t_sent *node, t_elst *lst);
-void	flag_redi_append(t_sent *node, t_elst *lst);
-void	flag_redi_trunc(t_sent *node, t_elst *lst);
+int		flag_redi_read(t_sent *node, t_elst *lst);
+int		flag_redi_append(t_sent *node, t_elst *lst);
+int		flag_redi_trunc(t_sent *node, t_elst *lst);
 
 /* src/executecmd/executecmd_util.c */
 void	ft_free_2d(char **targets);

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/22 16:04:46 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 21:17:30 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,11 @@ int	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 
 	menvp = dll_to_envp(lst);
 	path = ms_find_path(cmd->tokens[0], menvp);
+	if (cmd->output_flag == STDERR_FILENO)
+	{
+		ms_error(cmd->output_argv);
+		return (ft_free_check(path, menvp, 1));
+	}
 	if (check_path(path))
 		return (ft_free_check(path, menvp, 1));
 	pid = fork();

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,17 +6,17 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/21 16:44:01 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 16:04:46 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 int		run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
-void	child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
+int		child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
 void	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd);
 
-void	executecmd(t_deque *deque, t_elst *lst)
+int	executecmd(t_deque *deque, t_elst *lst)
 {
 	int		fd[2];
 	int		prev_fd;
@@ -31,7 +31,8 @@ void	executecmd(t_deque *deque, t_elst *lst)
 			pipe(fd);
 		if (dispatchcmd(cmd, lst))
 			continue ;
-		run_process(cmd, lst, fd, &prev_fd);
+		if (run_process(cmd, lst, fd, &prev_fd) < 0)
+			return (-1);
 	}
 }
 
@@ -50,16 +51,19 @@ int	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 		return (ft_free_check(path, menvp, 1));
 	if (pid == 0)
 	{
-		child_proc(cmd, lst, fd, prev_fd);
-		execute_node(cmd, menvp, path);
+		if (child_proc(cmd, lst, fd, prev_fd) < 0)
+			return (ft_free_check(path, menvp, -1));
+		if (execute_node(cmd, menvp, path) < 0)
+			return (ft_free_check(path, menvp, -1));
 	}
 	parent_proc(pid, cmd, fd, prev_fd);
 	return (ft_free_check(path, menvp, 0));
 }
 
-void	child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
+int	child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 {
-	run_by_flag(cmd, lst, INPUT);
+	if (run_by_flag(cmd, lst, INPUT) < 0)
+		return (-1);
 	if (*prev_fd != -1)
 		dup2(*prev_fd, STDIN_FILENO);
 	if (cmd->output_flag == PIPE_FLAG && fd[1] != -1)
@@ -67,7 +71,8 @@ void	child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 		close(fd[0]);
 		dup2(fd[1], STDOUT_FILENO);
 	}
-	run_by_flag(cmd, lst, OUTPUT);
+	if (run_by_flag(cmd, lst, OUTPUT) < 0)
+		return (-1);
 }
 
 void	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)
@@ -82,10 +87,11 @@ void	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)
 	}
 }
 
-void	execute_node(t_sent *node, char *menvp[], char *path)
+int	execute_node(t_sent *node, char *menvp[], char *path)
 {
 	if (node->tokens[0] == NULL || path == NULL)
-		exit(EXIT_SUCCESS);
+		return (-1);
 	execve(path, node->tokens, menvp);
 	ms_error("Failed to execute command\n");
+	exit(1);
 }

--- a/src/executecmd/executecmd_handler.c
+++ b/src/executecmd/executecmd_handler.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executecmd_handler.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minakim <minakim@student.42berlin.de>      +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 18:39:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/21 14:42:37 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/22 16:19:23 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ int	dispatchcmd(t_sent *node, t_elst *lst)
 typedef struct s_exe {
 	int		flag;
 	t_mode	type;
-	void	(*cmd_func)(t_sent *node, t_elst *lst);
+	int		(*cmd_func)(t_sent *node, t_elst *lst);
 }			t_exe;
 
 static int	compare_flags(t_sent *cmd, int current_flag, t_mode flag_type)
@@ -58,7 +58,7 @@ static int	compare_flags(t_sent *cmd, int current_flag, t_mode flag_type)
 	return (0);
 }
 
-void	run_by_flag(t_sent *cmd, t_elst *lst, t_mode flag)
+int	run_by_flag(t_sent *cmd, t_elst *lst, t_mode flag)
 {
 	static t_exe	exe_f[] = {
 	{HDOC_FLAG, INPUT, flag_heredoc},
@@ -73,10 +73,8 @@ void	run_by_flag(t_sent *cmd, t_elst *lst, t_mode flag)
 	while (exe_f[i].cmd_func != NULL)
 	{
 		if (flag == exe_f[i].type && compare_flags(cmd, exe_f[i].flag, flag))
-		{
-			exe_f[i].cmd_func(cmd, lst);
-			break ;
-		}
+			return (exe_f[i].cmd_func(cmd, lst));
 		i++;
 	}
+	return (0);
 }

--- a/src/executecmd/executecmd_util.c
+++ b/src/executecmd/executecmd_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/17 13:10:51 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/21 16:42:21 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 16:27:48 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,4 +65,3 @@ void	init_fd(int *fd, int *prev_fd)
 	fd[1] = -1;
 	*prev_fd = -1;
 }
-

--- a/src/executecmd/runheredoc.c
+++ b/src/executecmd/runheredoc.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 18:14:32 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/21 15:26:38 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 16:27:19 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,11 +63,16 @@ char	*replace_env_var(char *input, t_elst *lst)
 	return (buffer);
 }
 
-static void	child_heredoc(char *line, char *end_marker, int *fd, t_elst *lst)
+int	flag_heredoc(t_sent *node, t_elst *lst)
 {
+	char	*line;
+	char	*end_marker;
+	int		fd[2];
 	char	*expanded_line;
 
-	close(fd[0]);
+	line = NULL;
+	end_marker = node->input_argv;
+	pipe(fd);
 	while (1)
 	{
 		line = readline("heredoc> ");
@@ -81,32 +86,7 @@ static void	child_heredoc(char *line, char *end_marker, int *fd, t_elst *lst)
 		free(line);
 	}
 	close(fd[1]);
-	exit(0);
-}
-
-// implement heredoc handling and execution
-void	flag_heredoc(t_sent *node, t_elst *lst)
-{
-	char	*line;
-	char	*end_marker;
-	int		fd[2];
-	pid_t	pid;
-
-	line = NULL;
-	end_marker = node->input_argv;
-	pipe(fd);
-	pid = fork();
-	if (pid < 0)
-		ft_error();
-	if (pid == 0)
-	{
-		child_heredoc(line, end_marker, fd, lst);
-	}
-	else
-	{
-		close(fd[1]);
-		waitpid(pid, NULL, 0);
-		dup2(fd[0], STDIN_FILENO);
-		close(fd[0]);
-	}
+	dup2(fd[0], STDIN_FILENO);
+	close(fd[0]);
+	return (0);
 }

--- a/src/executecmd/runredi.c
+++ b/src/executecmd/runredi.c
@@ -3,17 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   runredi.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minakim <minakim@student.42berlin.de>      +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/13 12:12:54 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/18 18:56:56 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/22 14:09:35 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 // implement input redirection read handling and execution
-void	flag_redi_read(t_sent *node, t_elst *lst)
+int	flag_redi_read(t_sent *node, t_elst *lst)
 {
 	char	*filename;
 	int		fd;
@@ -22,13 +22,14 @@ void	flag_redi_read(t_sent *node, t_elst *lst)
 	filename = node->input_argv;
 	fd = open_file(filename, 2);
 	if (fd == -1)
-		return ;
+		return (fd);
 	dup2(fd, STDIN_FILENO);
 	close(fd);
+	return (0);
 }
 
 // Implement output redirection write append handling and execution
-void	flag_redi_append(t_sent *node, t_elst *lst)
+int	flag_redi_append(t_sent *node, t_elst *lst)
 {
 	char	*filename;
 	int		fd;
@@ -37,13 +38,14 @@ void	flag_redi_append(t_sent *node, t_elst *lst)
 	filename = node->output_argv;
 	fd = open_file(filename, 0);
 	if (fd == -1)
-		return ;
+		return (fd);
 	dup2(fd, STDOUT_FILENO);
 	close(fd);
+	return (0);
 }
 
 // Implement output redirection write trunc handling and execution
-void	flag_redi_trunc(t_sent *node, t_elst *lst)
+int	flag_redi_trunc(t_sent *node, t_elst *lst)
 {
 	char	*filename;
 	int		fd;
@@ -52,7 +54,8 @@ void	flag_redi_trunc(t_sent *node, t_elst *lst)
 	filename = node->output_argv;
 	fd = open_file(filename, 1);
 	if (fd == -1)
-		return ;
+		return (fd);
 	dup2(fd, STDOUT_FILENO);
 	close(fd);
+	return (0);
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/17 14:39:02 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/22 20:47:56 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,15 +50,16 @@ size_t	readcmd(char *cmd, int debug_mode)
 	return (total_len);
 }
 
-static void	looper(char *cmd, t_elst *lst, int debug_mode)
+static int	looper(char *cmd, t_elst *lst, int debug_mode)
 {
+	int		ret;
 	t_sent	*sent;
 	t_deque	*deque;
 
+	ret = 0;
 	deque = deque_init();
 	parsecmd(cmd, deque, lst, debug_mode);
 	sent = deque->end;
-
 	if (debug_mode)
 	{
 		ft_printf("\n");
@@ -66,11 +67,10 @@ static void	looper(char *cmd, t_elst *lst, int debug_mode)
 		ft_printf("\n");
 		ft_printf("------ result ------\n");
 	}
-
-	executecmd(deque, lst);
+	ret = executecmd(deque, lst);
 	sent_delall(&sent);
 	deque_del(deque);
-	return ;
+	return (ret);
 }
 
 int	main(int argc, char *argv[], char *envp[])
@@ -95,7 +95,8 @@ int	main(int argc, char *argv[], char *envp[])
 		readcmd(cmd, debug_mode);
 		if (isexit(cmd))
 			break ;
-		looper(cmd, lst, debug_mode);
+		if (looper(cmd, lst, debug_mode) < 0)
+			break ;
 	}
 	env_dellst(lst);
 	rl_clear_history();

--- a/src/parsecmd/parsecmd_tosent.c
+++ b/src/parsecmd/parsecmd_tosent.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/15 17:57:49 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/16 10:38:49 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 21:17:28 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,8 +21,8 @@ static int	handle_input(t_sent *node, char *margv[], int tmp)
 	{
 		node->output_flag = STDERR_FILENO;
 		node->output_argv = \
-			ft_strdup("syntax error: invalid token after redirection");
-		ft_error();
+			ft_strdup("syntax error: invalid token after redirection\n");
+		return (-1);
 	}
 	cnt++;
 	if (ft_strequ(margv[tmp], "<"))
@@ -42,8 +42,8 @@ static int	handle_output(t_sent *node, char *margv[], int tmp)
 	{
 		node->output_flag = STDERR_FILENO;
 		node->output_argv = \
-			ft_strdup("syntax error: invalid token after redirection");
-		ft_error();
+			ft_strdup("syntax error: invalid token after redirection\n");
+		return (-1);
 	}
 	cnt++;
 	if (ft_strequ(margv[tmp], ">"))

--- a/src/pipex.c
+++ b/src/pipex.c
@@ -6,11 +6,12 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 14:35:32 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/17 15:19:04 by minakim          ###   ########.fr       */
+/*   Updated: 2023/09/22 14:07:32 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "pipex.h"
+#include "minishell.h"
 
 int	open_file(char *argv, int option)
 {
@@ -24,7 +25,7 @@ int	open_file(char *argv, int option)
 	else if (option == 2)
 		file = open(argv, O_RDONLY, 0777);
 	if (file == -1)
-		ft_error();
+		ms_error("no such file\n");
 	return (file);
 }
 

--- a/src/t_sent/sent_delete.c
+++ b/src/t_sent/sent_delete.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/28 16:07:48 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/12 23:37:52 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 21:10:56 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,8 @@ void	sent_del(t_sent *sent)
 		(sent->input_flag == HDOC_FLAG))
 		free(sent->input_argv);
 	if ((sent->output_flag == REDI_WR_TRUNC_FLAG) || \
-		(sent->output_flag == REDI_WR_APPEND_FLAG))
+		(sent->output_flag == REDI_WR_APPEND_FLAG) || \
+		(sent->output_flag == STDERR_FILENO))
 		free(sent->output_argv);
 	free(sent->tokens);
 	free(sent->p_unit);


### PR DESCRIPTION
Resolve memory leaks from redirection and heredoc by rewinding returned value through inner function calls as error signals to main() function to exit and free memory allocation in the unsafely managed child process.

---

include/minishell.h
- 297-307: Update function prototype because of the change of function return value type, void into int.

src/executecmd/runheredoc.c
- 66-: Consolidate flag_heredoc() and child_heredoc() into flag_herecod with return type int, to remove fork() call to simplify process control and memory control.

src/executecmd/runredi.c
- Update all flag_redi_* related functions to return int, which will return 0 is normal but will return -1 if open_file is invalid.

src/executecmd/executecmd_handler.c
- 49: Change return type of function pointer in t_exe, from void to int, to make flag_ related functions to return int.
- 61,79: Change run_by_flag() to return int rathre than void, to rewind error signal up to the higher function through return value.
- 76: Remove unused lines of code.

src/executecmd/executecmd.c
- 19-35: Update executecmd() to return int value and to transfer the error signal with return values from inner function call, like run_process().
- 47-51: In run_process(), add new lines of code to check the output flag of a node and handle if node contains error.
- 59-62: Update run_process() to check the return values from child process function calls and handle error on child process and memory allocations.
- 68-80: Update child_proc() to check run_by_flag() calls for input and output flags and return -1 if something wrong on their function call.
- 95-101: Update execute_node() to return -1 if tokens for node or path are invalid.
- TODO) in line 101, may have to change it to return -1 value.

src/pipex.c
- 28: Modify open_file() function to call ms_error() and not exit the process.
src/parsecmd/parsecmd_tosent.c
- 24-25,45-46: Modify handle_input() and handle_output() functions not to call ft_error() and rather return -1 to let parser and executor know that the node need to be handle as error.

src/t_sent/sent_delete.c
- 33: Update sent_del() to free output argument if the flag if STDERR.

src/minishell.c
- 53-73: Update looper() to return int value and determined by return of executecmd() function call.
- 98-99: Update main() to check return value of looper() which rewind error signal through returned values and exit child process that is not properly executed.