### PR TITLE
fix: Remove potential memory leaks by exit()

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/22 15:23:56 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 22:24:16 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,7 +103,6 @@
 /* minishell.c */
 
 /* minishell_util.c */
-void	getcmd(char *cmd, size_t len, int debug_mode);
 int		isexit(char *cmd);
 int		ms_error(char *msg);
 
@@ -269,6 +268,10 @@ void	ft_export(t_sent *node, t_elst *lst);
 
 /*src/built-in/ft_unset */
 void	ft_unset(t_sent *node, t_elst *lst);
+
+/// readcmd
+/* src/readcmd/readcmd.c */
+size_t	readcmd(char *cmd, int debug_mode);
 
 /// parsecmd
 /* src/parsecmd/parsecmd.c */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/22 22:24:16 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/23 12:04:01 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -271,7 +271,7 @@ void	ft_unset(t_sent *node, t_elst *lst);
 
 /// readcmd
 /* src/readcmd/readcmd.c */
-size_t	readcmd(char *cmd, int debug_mode);
+int		readcmd(char *cmd, int debug_mode);
 
 /// parsecmd
 /* src/parsecmd/parsecmd.c */

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/22 21:17:30 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 21:46:59 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,5 +98,5 @@ int	execute_node(t_sent *node, char *menvp[], char *path)
 		return (-1);
 	execve(path, node->tokens, menvp);
 	ms_error("Failed to execute command\n");
-	exit(1);
+	return (-1);
 }

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/22 21:46:59 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/23 12:07:04 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,6 @@ int	executecmd(t_deque *deque, t_elst *lst)
 {
 	int		fd[2];
 	int		prev_fd;
-	pid_t	pid;
 	t_sent	*cmd;
 
 	init_fd(fd, &prev_fd);
@@ -34,6 +33,7 @@ int	executecmd(t_deque *deque, t_elst *lst)
 		if (run_process(cmd, lst, fd, &prev_fd) < 0)
 			return (-1);
 	}
+	return (0);
 }
 
 int	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
@@ -78,6 +78,7 @@ int	child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 	}
 	if (run_by_flag(cmd, lst, OUTPUT) < 0)
 		return (-1);
+	return (0);
 }
 
 void	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -6,33 +6,11 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/21 16:32:00 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/22 21:50:58 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
-
-void	getcmd(char *cmd, size_t len, int debug_mode)
-{
-	char	*command;
-
-	if (debug_mode)
-		command = readline("미쉘(debug)> ");
-	else
-		command = readline("미쉘> ");
-	if (!command)
-	{
-		ft_putstr_fd("exit\n", STDOUT_FILENO);
-		exit(EXIT_SUCCESS);
-	}
-	len = ft_strlen(command);
-	if (len > MAX_COMMAND_LEN)
-		ft_putstr_fd("warn: command exceed MAX_COMMAND_LEN\n", 2);
-	ft_strlcpy(cmd, command, len + 1);
-	if (ft_strncmp(command, "", 1))
-		add_history(command);
-	free(command);
-}
 
 int	isexit(char *cmd)
 {

--- a/src/readcmd/readcmd.c
+++ b/src/readcmd/readcmd.c
@@ -6,13 +6,13 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/22 21:48:32 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/22 22:24:11 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/23 12:03:51 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int	getcmd(char *cmd, size_t len, int debug_mode)
+static int	getcmd(char *cmd, int len, int debug_mode)
 {
 	char	*command;
 
@@ -22,7 +22,7 @@ static int	getcmd(char *cmd, size_t len, int debug_mode)
 		command = readline("미쉘> ");
 	if (!command)
 	{
-		ft_putstr_fd("exit\n", STDOUT_FILENO);
+		ft_putstr_fd("exit\n", STDIN_FILENO);
 		return (-1);
 	}
 	len = ft_strlen(command);
@@ -35,9 +35,9 @@ static int	getcmd(char *cmd, size_t len, int debug_mode)
 	return (0);
 }
 
-static int	looper_readcmd(char *cmd, char *temp_cmd, size_t *total_len)
+static int	looper_readcmd(char *cmd, char *temp_cmd, int *total_len)
 {
-	size_t	len;
+	int	len;
 
 	len = 0;
 	len = ft_strcspn(temp_cmd, "\n");
@@ -54,10 +54,10 @@ static int	looper_readcmd(char *cmd, char *temp_cmd, size_t *total_len)
 	return (1);
 }
 
-size_t	readcmd(char *cmd, int debug_mode)
+int	readcmd(char *cmd, int debug_mode)
 {
 	int		looper;
-	size_t	total_len;
+	int		total_len;
 	char	temp_cmd[MAX_COMMAND_LEN];
 
 	ft_bzero(cmd, MAX_COMMAND_LEN);

--- a/src/readcmd/readcmd.c
+++ b/src/readcmd/readcmd.c
@@ -1,0 +1,78 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   readcmd.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/09/22 21:48:32 by sanghupa          #+#    #+#             */
+/*   Updated: 2023/09/22 22:24:11 by sanghupa         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	getcmd(char *cmd, size_t len, int debug_mode)
+{
+	char	*command;
+
+	if (debug_mode)
+		command = readline("미쉘(debug)> ");
+	else
+		command = readline("미쉘> ");
+	if (!command)
+	{
+		ft_putstr_fd("exit\n", STDOUT_FILENO);
+		return (-1);
+	}
+	len = ft_strlen(command);
+	if (len > MAX_COMMAND_LEN)
+		ft_putstr_fd("warn: command exceed MAX_COMMAND_LEN\n", 2);
+	ft_strlcpy(cmd, command, len + 1);
+	if (ft_strncmp(command, "", 1))
+		add_history(command);
+	free(command);
+	return (0);
+}
+
+static int	looper_readcmd(char *cmd, char *temp_cmd, size_t *total_len)
+{
+	size_t	len;
+
+	len = 0;
+	len = ft_strcspn(temp_cmd, "\n");
+	if (len + *total_len > MAX_COMMAND_LEN)
+		return (-1);
+	if (len == 0 || temp_cmd[len - 1] != '\\')
+	{
+		ft_strlcat(cmd, temp_cmd, *total_len + len + 1);
+		*total_len += len;
+		return (0);
+	}
+	ft_strlcat(cmd, temp_cmd, *total_len + len);
+	*total_len += len;
+	return (1);
+}
+
+size_t	readcmd(char *cmd, int debug_mode)
+{
+	int		looper;
+	size_t	total_len;
+	char	temp_cmd[MAX_COMMAND_LEN];
+
+	ft_bzero(cmd, MAX_COMMAND_LEN);
+	looper = 1;
+	total_len = 0;
+	if (*cmd != '\0')
+		return (-1);
+	while (looper)
+	{
+		if (getcmd(temp_cmd, 0, debug_mode) < 0)
+			return (-1);
+		looper = looper_readcmd(cmd, temp_cmd, &total_len);
+	}
+	if (looper < 0)
+		return (-1);
+	cmd[total_len] = '\0';
+	return (total_len);
+}


### PR DESCRIPTION
include/minishell.h
- 106,274: Update header file because of the refactor on minishell.c file and extracting readcmd() to external file.

src/minishell.c
- Extract readcmd() to external directory with new file.
- Add new function looper_wrapper() to wrap lines of code in while loop at main(), to resolve norm error.
- 76: Refactor main() to resolve norm error.

src/minishell_util.c
- Extract getcmd() to external directory with new file.

src/readcmd/readcmd.c
- Move getcmd() and modify the function to return int value depends on the process.
- Add new function looper_readcmd() to fix norm error in previous readcmd() by extracting lines of code in while loop, and return value to control while loop in readcmd().
- Move readcmd() from minishell.c file and modify the function to return error with int -1 to main() if error.

src/executecmd/executecmd.c
- 101: Modify execute_node() to return -1 if execve() went wrong.