### PR TITLE
fix: Resolve heredoc readline memoryleak and signal handler

### DIFF
--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/22 21:50:55 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/27 00:12:46 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 static void	sighandler(int signal)
 {
 	(void)signal;
-	printf("\n");
+	write(1, "\n", 1);
 	rl_replace_line("", 0);
 	rl_on_new_line();
 	rl_redisplay();


### PR DESCRIPTION
src/minishell.c
- 18: Edit signalhandler() to the allowed function.

src/executecmd/runheredoc.c
- 15-18: Add new struct to store char *line to make it as singleton struct.
- 20-32: Add new function hdoc() that return static t_hdoc everytime it is been called, which makes t_hdoc as a singleton struct.
- 34-39: Add new signal handler sighandler_heredoc() to handle ctrl-C during heredoc and clear rl history and free it.
- In flag_heredoc(), apply hdoc() to get access at sighandler_heredoc(), and apply sighandler_heredoc().

TODO: norm check & make singleton struct for global like usage values. (t_env, t_sent, deque, elst, etc.)