### PR TITLE
feat: Make built-in functions able to pipe

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/23 16:32:02 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/28 13:11:59 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -301,9 +301,12 @@ typedef enum e_mode{
 /// execute
 /* src/executecmd/executecmd.c */
 int		executecmd(t_deque *deque, t_elst *lst);
+int		run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
+int		child_proc(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd);
+void	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd);
 int		execute_node(t_sent *node, char *menvp[], char *path);
 int		run_by_flag(t_sent *cmd, t_elst *lst, t_mode flag);
-int		dispatchcmd(t_sent *node, t_elst *lst);
+int		dispatchcmd(t_sent *node, t_elst *lst, int *fd, int *prev_fd);
 /// list of executable flags
 /* src/executecmd/runheredoc.c */
 int		flag_heredoc(t_sent *node, t_elst *lst);

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/23 12:07:04 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/28 13:22:36 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@ int	executecmd(t_deque *deque, t_elst *lst)
 {
 	int		fd[2];
 	int		prev_fd;
+	int		bt;
 	t_sent	*cmd;
 
 	init_fd(fd, &prev_fd);
@@ -28,7 +29,10 @@ int	executecmd(t_deque *deque, t_elst *lst)
 		cmd = deque_pop_back(deque);
 		if (cmd->output_flag == PIPE_FLAG)
 			pipe(fd);
-		if (dispatchcmd(cmd, lst))
+		bt = dispatchcmd(cmd, lst, fd, &prev_fd);
+		if (bt < 0)
+			return (-1);
+		if (bt)
 			continue ;
 		if (run_process(cmd, lst, fd, &prev_fd) < 0)
 			return (-1);

--- a/src/readcmd/readcmd.c
+++ b/src/readcmd/readcmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/22 21:48:32 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/09/23 12:03:51 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/09/28 13:39:13 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ static int	getcmd(char *cmd, int len, int debug_mode)
 		ft_putstr_fd("warn: command exceed MAX_COMMAND_LEN\n", 2);
 	ft_strlcpy(cmd, command, len + 1);
 	if (ft_strncmp(command, "", 1))
-		add_history(command);
+		add_history(cmd);
 	free(command);
 	return (0);
 }


### PR DESCRIPTION
include/minishell.h
- 304-306: Add prototype to reuse in built-in functions.
- 309: Update prototype of dispatchcmd().

src/executecmd/executecmd.c
- In executecmd(), edit dispatchcmd() function to return value and return child process to exit.

src/executecmd/executecmd_handler.c
- 21-38: Add new function builtins() to return array of built-in functions in singleton way.
- 40-44: Add new function dispatch_err() to reduce number of line for dispatchcmd().
- Update dispatchcmd() to be able to work with pipe.

src/readcmd/readcmd.c
- 33: Edit add_history() to add reference from static value in function not from readline() which make potential leak.
