### PR TITLE
fix: echo with no additional token

### DIFF
--- a/src/built-in/ft_echo.c
+++ b/src/built-in/ft_echo.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/03 19:43:37 by minakim           #+#    #+#             */
-/*   Updated: 2023/09/23 16:23:19 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/01 21:22:20 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,18 +91,21 @@ void	ft_echo(t_sent *node, t_elst *lst)
 	i = 0;
 	fd = redi_out(node);
 	if (node->tokens[1])
-		term = determine_term(node->tokens[1], &i);
-	while (++i < node->tokens_len && node->tokens[i])
 	{
-		if (ft_strequ(node->tokens[i], "~"))
-			echo_homepath(lst);
-		else
-			ft_putstr_fd(node->tokens[i], fd);
-		if (i + 1 < node->tokens_len && \
-			node->tokens[i + 1] != NULL)
-			ft_putchar_fd(' ', fd);
+		term = determine_term(node->tokens[1], &i);
+		while (++i < node->tokens_len && node->tokens[i])
+		{
+			if (ft_strequ(node->tokens[i], "~"))
+				echo_homepath(lst);
+			else
+				ft_putstr_fd(node->tokens[i], fd);
+			if (i + 1 < node->tokens_len && node->tokens[i + 1] != NULL)
+				ft_putchar_fd(' ', fd);
+		}
+		ft_putchar_fd(term, fd);
 	}
-	ft_putchar_fd(term, fd);
+	else
+		ft_putendl_fd("", fd);
 	if (fd != 1)
 		close(fd);
 	lst->g_exit = 0;


### PR DESCRIPTION
**Problem**

- There is an error when `echo` with no argument or no token.

Report from the valgrind.

```bash
미 쉘 > echo 

...

==18155== 1 errors in context 1 of 1:
==18155== Syscall param write(buf) points to uninitialised byte(s)
==18155==    at 0x49C7A37: write (write.c:26)
==18155==    by 0x10F255: ft_putchar_fd (in /dorker_workspace/minishell/minishell)
==18155==    by 0x109AFE: ft_echo (ft_echo.c:105)
==18155==    by 0x10AE9A: dispatchcmd (executecmd_disptach_handler.c:66)
==18155==    by 0x10AF33: dispatchcmd_wrapper (executecmd_disptach_handler.c:82)
==18155==    by 0x10A831: executecmd (executecmd.c:31)
==18155==    by 0x10B851: looper (minishell.c:41)
==18155==    by 0x10B8DC: looper_wrapper (minishell.c:53)
==18155==    by 0x10BA05: main (minishell.c:76)
==18155==  Address 0x1ffefff7ac is on thread 1's stack
==18155==  in frame #1, created by ft_putchar_fd (???:)
==18155==
--18155--
--18155-- used_suppression:     64 leak readline readline.txt:2 suppressed: 204,098 bytes in 223 blocks
--18155-- used_suppression:      1 leak add_history readline.txt:8 suppressed: 4,016 bytes in 1 blocks
==18155==
==18155== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

**Solution**

Solve the error by giving `else` statement to pass if there are no token for `echo`.
