### PR TITLE
fix: pipe && executecmd.c

### DIFF
--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/06 17:54:23 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/08 15:41:42 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,18 +85,18 @@ int	child_proc(t_sent *cmd, int *fd, int *prev_fd)
 	return (0);
 }
 
-int parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)
+int	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)
 {
-	int status;
-	int result;
+	int	status;
+	int	result;
 
 	result = -1;
-	if (cmd->input_flag == HDOC_FLAG)
+	if (cmd->next == NULL)
+	{
 		waitpid(pid, &status, 0);
-	else
-		waitpid(pid, &status, WNOHANG);
-	if (WIFEXITED(status))
-		result = WEXITSTATUS(status);
+		if (WIFEXITED(status))
+			result = WEXITSTATUS(status);
+	}
 	if (*prev_fd != -1)
 		close(*prev_fd);
 	if (cmd->output_flag == PIPE_FLAG)


### PR DESCRIPTION
`parent_proc` function is set up to wait for the child process only if`cmd->next` is `NULL,  last command in the sequence.

src/executecmd.c

```c
int	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)
{
 ...
if (cmd->next == NULL) // last command 
	{
		waitpid(pid, &status, 0);
		if (WIFEXITED(status))
			result = WEXITSTATUS(status);
	}
}
```
