### PR TITLE
feat: Update tokenizer to parse "abc"abd kinds

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/04 22:39:59 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/12 13:27:38 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -335,11 +335,16 @@ int		flag_redi_trunc(t_sent *node, t_elst *lst);
 /* src/executecmd/executecmd_util.c */
 void	ft_free_2d(char **targets);
 int		ft_free_check(char *path, char *menvp[], int ret);
-char	*ms_find_path(char *cmd, char *envp[]);
+char	*ms_find_path(char *cmd);
 void	init_fd(int *fd, int *prev_fd);
 
 /* src/executecmd/executecmd_check.c */
 int		check_path(char *path, char *cmd);
 int		check_pid(pid_t pid);
+
+/* src/util/ms_split.c */
+size_t	ms_split_size(char const *s, char c);
+char	**ms_split_process(char const *s, char c, char **tmp, size_t i);
+char	**ms_split(char const *s, char c);
 
 #endif

--- a/src/built-in/ft_exit.c
+++ b/src/built-in/ft_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_exit.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minakim <minakim@student.42berlin.de>      +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/04 18:50:24 by minakim           #+#    #+#             */
-/*   Updated: 2023/10/06 16:01:18 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/12 12:51:15 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@ static int	ft_atoi_exit(const char *s)
 {
 	int	symbol;
 	int	num;
-	int i;
+	int	i;
 
 	i = 0;
 	num = 0;

--- a/src/built-in/ft_unset.c
+++ b/src/built-in/ft_unset.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/21 14:40:09 by minakim           #+#    #+#             */
-/*   Updated: 2023/10/04 15:00:51 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/12 12:51:37 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,11 +38,11 @@ void	ft_unset(t_sent *node, t_elst *lst)
 	int		fd;
 
 	fd = redi_out(node);
-		key = node->tokens[1];
-		ft_unsetenv(key, lst);
-		if (fd != 1)
-			close(fd);
-		lst->g_exit = 0;
+	key = node->tokens[1];
+	ft_unsetenv(key, lst);
+	if (fd != 1)
+		close(fd);
+	lst->g_exit = 0;
 }
 
 //void	ft_unset(t_sent *node, t_elst *lst)

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/12 13:32:39 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/13 17:12:10 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -109,7 +109,6 @@ int	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)
 
 int	execute_node(t_sent *node, char *menvp[], char *path)
 {
-	size_t	i;
 	size_t	tmp_size;
 	char	**tmp;
 

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/08 15:01:20 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/08 15:41:42 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/12 13:32:39 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ int	run_process(t_sent *cmd, t_elst *lst, int *fd, int *prev_fd)
 	char	*path;
 
 	menvp = dll_to_envp(lst);
-	path = ms_find_path(cmd->tokens[0], menvp);
+	path = ms_find_path(cmd->tokens[0]);
 	if (cmd->output_flag == STDERR_FILENO)
 	{
 		ms_error(cmd->output_argv);
@@ -109,8 +109,20 @@ int	parent_proc(int pid, t_sent *cmd, int *fd, int *prev_fd)
 
 int	execute_node(t_sent *node, char *menvp[], char *path)
 {
+	size_t	i;
+	size_t	tmp_size;
+	char	**tmp;
+
 	if (node->tokens[0] == NULL || path == NULL)
 		return (-1);
+	if (node->tokens[0][0] == '/')
+	{
+		tmp_size = ms_split_size(node->tokens[0], '/');
+		tmp = (char **)malloc(sizeof(char *) * (tmp_size + 1));
+		tmp = ms_split_process(node->tokens[0], '/', tmp, 0);
+		node->tokens[0] = ft_strdup(tmp[tmp_size - 1]);
+		ft_free_2d(tmp);
+	}
 	execve(path, node->tokens, menvp);
 	ms_error("Failed to execute command\n");
 	return (-1);

--- a/src/executecmd/executecmd_disptach_handler.c
+++ b/src/executecmd/executecmd_disptach_handler.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/18 18:39:49 by minakim           #+#    #+#             */
-/*   Updated: 2023/10/06 15:54:53 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/12 12:57:17 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,14 +44,8 @@ int	dispatch_err(t_sent *node)
 	return (-1);
 }
 
-int	dispatchcmd(t_sent *node, int *fd, int *prev_fd, int ctab_i)
+int	dispatch_nofork(t_sent *node, int ctab_i, t_cmd *cmd_tab)
 {
-	t_cmd	*cmd_tab;
-	pid_t	pid;
-
-	cmd_tab = builtins();
-	if (node->output_flag == STDERR_FILENO)
-		return (dispatch_err(node));
 	if (ft_strequ(cmd_tab[ctab_i].cmd_name, "exit"))
 	{
 		cmd_tab[ctab_i].cmd_func(node, ms_env());
@@ -64,6 +58,21 @@ int	dispatchcmd(t_sent *node, int *fd, int *prev_fd, int ctab_i)
 		cmd_tab[ctab_i].cmd_func(node, ms_env());
 		return (1);
 	}
+	return (0);
+}
+
+int	dispatchcmd(t_sent *node, int *fd, int *prev_fd, int ctab_i)
+{
+	int		ret;
+	t_cmd	*cmd_tab;
+	pid_t	pid;
+
+	cmd_tab = builtins();
+	if (node->output_flag == STDERR_FILENO)
+		return (dispatch_err(node));
+	ret = dispatch_nofork(node, ctab_i, cmd_tab);
+	if (ret != 0)
+		return (ret);
 	pid = fork();
 	g_sigstatus = 1;
 	if (pid == 0)

--- a/src/executecmd/executecmd_util.c
+++ b/src/executecmd/executecmd_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/17 13:10:51 by minakim           #+#    #+#             */
-/*   Updated: 2023/10/06 17:39:52 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/12 13:35:54 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,19 +30,20 @@ int	ft_free_check(char *path, char *menvp[], int ret)
 	return (ret);
 }
 
-char	*ms_find_path(char *cmd, char *envp[])
+char	*ms_find_path(char *cmd)
 {
 	int		i;
 	char	**paths;
 	char	*ppath;
 	char	*path;
 
-	(void)envp;
+	if (cmd[0] == '/')
+		return (ft_strdup(cmd));
 	if (!ft_getenv(ms_env(), "PATH"))
 		return (0);
 	paths = ft_split(ft_getenv(ms_env(), "PATH") + 5, ':');
-	i = 0;
-	while (paths[i] != NULL)
+	i = -1;
+	while (paths[++i] != NULL)
 	{
 		ppath = ft_strjoin(paths[i], "/");
 		path = ft_strjoin(ppath, cmd);
@@ -53,7 +54,6 @@ char	*ms_find_path(char *cmd, char *envp[])
 			return (path);
 		}
 		free(path);
-		i++;
 	}
 	ft_free_2d(paths);
 	return (0);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/06 16:04:48 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/12 12:52:26 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,13 +82,12 @@ static int	looper_wrapper(char *cmd, int debug_mode)
 
 int	main(int argc, char *argv[], char *envp[])
 {
-	int		debug_mode;
-	int		exit_status;
-	char	cmd[MAX_COMMAND_LEN];
-	t_elst	*lst;
+	static int	debug_mode;
+	int			exit_status;
+	char		cmd[MAX_COMMAND_LEN];
+	t_elst		*lst;
 
 	exit_status = 0;
-	debug_mode = FALSE;
 	if (argc > 1 && (ft_strequ(argv[1], "--debug") \
 		|| ft_strequ(argv[1], "-d")))
 		debug_mode = TRUE;

--- a/src/parsecmd/parsecmd_tokenize.c
+++ b/src/parsecmd/parsecmd_tokenize.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/25 23:43:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/12 13:03:32 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/14 15:06:18 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,12 +19,23 @@ int	get_margc(char *cmd)
 {
 	int		i;
 	int		cnt;
+	uint8_t	quote_s;
+	uint8_t	quote_d;
 
 	i = -1;
 	cnt = 0;
+	quote_s = 0;
+	quote_d = 0;
 	while (cmd[++i])
+	{
+		if (cmd[i] == '\'' && quote_d != 1)
+			quote_s ^= 1;
+		else if (cmd[i] == '\"' && quote_s != 1)
+			quote_d ^= 1;
 		if (!ft_isspace(cmd[i]) && (ft_isspace(cmd[i + 1]) || !(cmd[i + 1])))
-			cnt++;
+			if (!quote_s && !quote_d)
+				cnt++;
+	}
 	return (cnt);
 }
 
@@ -42,11 +53,19 @@ static int	skip_spaces(char *s)
 static int	get_nexti(char *s)
 {
 	int		i;
+	uint8_t	quote_s;
+	uint8_t	quote_d;
 
 	i = -1;
+	quote_s = 0;
+	quote_d = 0;
 	while (s[++i])
 	{
-		if (ft_isspace(s[i]))
+		if (s[i] == '\'' && quote_d != 1)
+			quote_s ^= 1;
+		else if (s[i] == '\"' && quote_s != 1)
+			quote_d ^= 1;
+		if (!quote_s && !quote_d && ft_isspace(s[i]))
 			break ;
 	}
 	return (i);

--- a/src/parsecmd/parsecmd_tokenize.c
+++ b/src/parsecmd/parsecmd_tokenize.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   parse_quotes.c                                     :+:      :+:    :+:   */
+/*   parsecmd_tokenize.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/25 23:43:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/08/25 23:45:51 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/12 12:42:50 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,12 +28,14 @@ int	get_margc(char *cmd)
 	quote_d = 0;
 	while (cmd[++i])
 	{
-		if (cmd[i] == '\'' && quote_d != 1)
-			quote_s ^= 1;
-		else if (cmd[i] == '\"' && quote_s != 1)
-			quote_d ^= 1;
-		if (!quote_s && !quote_d && !ft_isspace(cmd[i]) && \
-			(ft_isspace(cmd[i + 1]) || !(cmd[i + 1])))
+		// if (cmd[i] == '\'' && quote_d != 1)
+		// 	quote_s ^= 1;
+		// else if (cmd[i] == '\"' && quote_s != 1)
+		// 	quote_d ^= 1;
+		// if (!quote_s && !quote_d && !ft_isspace(cmd[i]) && \
+		// 	(ft_isspace(cmd[i + 1]) || !(cmd[i + 1])))
+		// 	cnt++;
+		if (!ft_isspace(cmd[i]) && (ft_isspace(cmd[i + 1]) || !(cmd[i + 1])))
 			cnt++;
 	}
 	return (cnt);
@@ -61,14 +63,35 @@ static int	get_nexti(char *s)
 	quote_d = 0;
 	while (s[++i])
 	{
-		if (s[i] == '\'' && quote_d != 1)
-			quote_s ^= 1;
-		else if (s[i] == '\"' && quote_s != 1)
-			quote_d ^= 1;
-		if (!quote_s && !quote_d && ft_isspace(s[i]))
+		if (ft_isspace(s[i]))
 			break ;
 	}
 	return (i);
+}
+
+char	*ms_strndup(const char *src, size_t len)
+{
+	int		i;
+	int		j;
+	char	*new;
+
+	new = (char *)ft_memalloc(len + 1);
+	if (!new)
+		return (NULL);
+	i = -1;
+	j = -1;
+	while (src[++i] != '\0' && i < len)
+	{
+		if ((src[i] == '\"') || (src[i] == '\''))
+			continue ;
+		new[++j] = src[i];
+	}
+	while (i < len)
+	{
+		new[i] = '\0';
+		i++;
+	}
+	return (new);
 }
 
 char	**get_margv(char *cmd, int margc)
@@ -81,16 +104,12 @@ char	**get_margv(char *cmd, int margc)
 	margv = (char **)ft_memalloc(sizeof(char *) * (margc + 1));
 	i = -1;
 	select = 0;
+	ft_printf("margc: %d\n", margc);
 	while (++i < margc)
 	{
 		select += skip_spaces(&cmd[select]);
 		nexti = get_nexti(&cmd[select]);
-		if (cmd[select] == '\"')
-			margv[i] = ft_strcdup(&cmd[select + 1], '\"');
-		else if (cmd[select] == '\'')
-			margv[i] = ft_strcdup(&cmd[select + 1], '\'');
-		else
-			margv[i] = ft_strndup(&cmd[select], nexti);
+		margv[i] = ms_strndup(&cmd[select], nexti);
 		select += nexti;
 	}
 	return (margv);

--- a/src/parsecmd/parsecmd_tokenize.c
+++ b/src/parsecmd/parsecmd_tokenize.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/25 23:43:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/12 12:42:50 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/12 12:49:58 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,25 +19,12 @@ int	get_margc(char *cmd)
 {
 	int		i;
 	int		cnt;
-	uint8_t	quote_s;
-	uint8_t	quote_d;
 
 	i = -1;
 	cnt = 0;
-	quote_s = 0;
-	quote_d = 0;
 	while (cmd[++i])
-	{
-		// if (cmd[i] == '\'' && quote_d != 1)
-		// 	quote_s ^= 1;
-		// else if (cmd[i] == '\"' && quote_s != 1)
-		// 	quote_d ^= 1;
-		// if (!quote_s && !quote_d && !ft_isspace(cmd[i]) && \
-		// 	(ft_isspace(cmd[i + 1]) || !(cmd[i + 1])))
-		// 	cnt++;
 		if (!ft_isspace(cmd[i]) && (ft_isspace(cmd[i + 1]) || !(cmd[i + 1])))
 			cnt++;
-	}
 	return (cnt);
 }
 
@@ -55,12 +42,8 @@ static int	skip_spaces(char *s)
 static int	get_nexti(char *s)
 {
 	int		i;
-	uint8_t	quote_s;
-	uint8_t	quote_d;
 
 	i = -1;
-	quote_s = 0;
-	quote_d = 0;
 	while (s[++i])
 	{
 		if (ft_isspace(s[i]))
@@ -69,7 +52,7 @@ static int	get_nexti(char *s)
 	return (i);
 }
 
-char	*ms_strndup(const char *src, size_t len)
+char	*ms_strndup(const char *src, int len)
 {
 	int		i;
 	int		j;

--- a/src/parsecmd/parsecmd_tokenize.c
+++ b/src/parsecmd/parsecmd_tokenize.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/25 23:43:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/12 12:49:58 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/12 13:03:32 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,7 +87,6 @@ char	**get_margv(char *cmd, int margc)
 	margv = (char **)ft_memalloc(sizeof(char *) * (margc + 1));
 	i = -1;
 	select = 0;
-	ft_printf("margc: %d\n", margc);
 	while (++i < margc)
 	{
 		select += skip_spaces(&cmd[select]);

--- a/src/util/ms_split.c
+++ b/src/util/ms_split.c
@@ -1,0 +1,71 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ms_split.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/10/12 13:25:28 by sanghupa          #+#    #+#             */
+/*   Updated: 2023/10/12 13:26:02 by sanghupa         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+
+size_t	ms_split_size(char const *s, char c)
+{
+	size_t	len;
+
+	len = 0;
+	while (*s)
+	{
+		if (*s != c)
+		{
+			len++;
+			while (*s && *s != c)
+				s++;
+		}
+		if (*s)
+			s++;
+	}
+	return (len);
+}
+
+char	**ms_split_process(char const *s, char c, char **tmp, size_t i)
+{
+	char	*start;
+
+	while (*s)
+	{
+		if (*s != c)
+		{
+			start = (char *)s;
+			while (*s && *s != c)
+				s++;
+			tmp[i] = (char *)malloc(sizeof(char) * (s - start + 1));
+			if (!tmp[i])
+				return (NULL);
+			ft_strlcpy(tmp[i++], start, s - start + 1);
+		}
+		if (*s)
+			s++;
+	}
+	tmp[i] = NULL;
+	return (tmp);
+}
+
+char	**ms_split(char const *s, char c)
+{
+	char	**tmp;
+	size_t	i;
+
+	if (!s)
+		return (NULL);
+	tmp = (char **)malloc(sizeof(char *) * (ms_split_size(s, c) + 1));
+	if (!tmp)
+		return (NULL);
+	i = 0;
+	tmp = ms_split_process(s, c, tmp, i);
+	return (tmp);
+}


### PR DESCRIPTION
- Our 미쉘 can parse `"abc"abc` kind of unspaced cmd as token.
- Our 미쉘 can process execution of absolute path command, like `/usr/bin/ls -al`.