### PR TITLE
Feat/parsing pipe

### DIFF
--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:41:35 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/20 18:18:20 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/21 14:05:38 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,6 @@ uint8_t	g_sigstatus;
 
 static void	start_minishell(void)
 {
-//	sigchld();
 	ft_putendl_fd("\n", 1);
 	ft_putendl_fd("  ████████████████████████████████████████████████  ", 1);
 	ft_putendl_fd("██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██", 1);
@@ -65,7 +64,8 @@ static int	looper(char *cmd, int debug_mode)
 		ft_printf("\n");
 		ft_printf("------ result ------\n");
 	}
-	ret = executecmd(deque);
+	if (deque->size > 0)
+		ret = executecmd(deque);
 	sent_delall(&sent);
 	deque_del(deque);
 	return (ret);
@@ -84,11 +84,10 @@ static int	looper_wrapper(char *cmd, int debug_mode)
 int	main(int argc, char *argv[], char *envp[])
 {
 	static int	debug_mode;
-	int			exit_status;
+	static int	exit_status;
 	char		cmd[MAX_COMMAND_LEN];
 	t_elst		*lst;
 
-	exit_status = 0;
 	if (argc > 1 && (ft_strequ(argv[1], "--debug") \
 		|| ft_strequ(argv[1], "-d")))
 		debug_mode = TRUE;

--- a/src/minishell_util.c
+++ b/src/minishell_util.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/18 16:21:57 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/20 18:18:07 by minakim          ###   ########.fr       */
+/*   Updated: 2023/10/21 12:39:38 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,5 +35,7 @@ int	ms_error(char *msg)
 void	sigchldhandler(int signo)
 {
 	(void)signo;
-	while (waitpid(-1, NULL, WNOHANG) > 0);
+	while (waitpid(-1, NULL, WNOHANG) > 0)
+	{
+	}
 }

--- a/src/parsecmd/parsecmd_tokenize.c
+++ b/src/parsecmd/parsecmd_tokenize.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/25 23:43:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/10/14 15:06:18 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/10/21 14:24:26 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,9 +32,14 @@ int	get_margc(char *cmd)
 			quote_s ^= 1;
 		else if (cmd[i] == '\"' && quote_s != 1)
 			quote_d ^= 1;
-		if (!ft_isspace(cmd[i]) && (ft_isspace(cmd[i + 1]) || !(cmd[i + 1])))
-			if (!quote_s && !quote_d)
+		if (!quote_s && !quote_d)
+		{
+			if (!ft_isspace(cmd[i]) && \
+				(ft_isspace(cmd[i + 1]) || !(cmd[i + 1]) || cmd[i + 1] == '|'))
 				cnt++;
+			else if (cmd[i] == '|')
+				cnt++;
+		}
 	}
 	return (cnt);
 }
@@ -65,9 +70,11 @@ static int	get_nexti(char *s)
 			quote_s ^= 1;
 		else if (s[i] == '\"' && quote_s != 1)
 			quote_d ^= 1;
-		if (!quote_s && !quote_d && ft_isspace(s[i]))
+		if (!quote_s && !quote_d && (ft_isspace(s[i]) || s[i] == '|'))
 			break ;
 	}
+	if (i == 0)
+		i++;
 	return (i);
 }
 
@@ -77,6 +84,8 @@ char	*ms_strndup(const char *src, int len)
 	int		j;
 	char	*new;
 
+	if (len == 0)
+		len = 1;
 	new = (char *)ft_memalloc(len + 1);
 	if (!new)
 		return (NULL);


### PR DESCRIPTION
- Enable to parse pipes `|` without spaces between commands.
- Fix a bug that when there is empty enter as a input the minishell exit.