### PR TITLE
Fix/parse quotes ctrl backslash redirection

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghupa <sanghupa@student.42.fr>          +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/11/01 14:29:49 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/11/02 10:54:20 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -301,8 +301,7 @@ int		split_cmd(t_sent *node, char *margv[], int select, int i);
 int		check_quotes(char *cmd, int index, int status);
 void	expand_cmd(char *cmd);
 int		append_env(char *str, char *cmd);
-int		ms_strndup_helper(const char *src, int i, 
-			uint8_t quote_s, uint8_t quote_d);
+int		ms_strndup_helper(const char *src, char *new, int len);
 
 typedef enum e_mode{
 	NONE,

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/15 14:06:17 by minakim           #+#    #+#             */
-/*   Updated: 2023/11/02 11:30:13 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/11/02 13:13:29 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,9 +51,15 @@ int	ft_execvp(t_sent *cmd)
 	char	**menvp;
 	char	*path;
 
+	if (cmd->tokens[0][0] == '|')
+	{
+		cmd->output_flag = STDERR_FILENO;
+		cmd->output_argv = \
+			ft_strdup("syntax error: near unexpected token `|`\n");
+	}
 	if (cmd->output_flag == STDERR_FILENO)
 	{
-		ms_error(cmd->output_argv);
+		ft_putstr_fd(cmd->output_argv, 2);
 		return (1);
 	}
 	else

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executecmd.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minakim <minakim@student.42berlin.de>      +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/15 14:06:17 by minakim           #+#    #+#             */
-/*   Updated: 2023/11/01 14:42:17 by minakim          ###   ########.fr       */
+/*   Updated: 2023/11/02 11:30:13 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,7 @@ int	ft_execvp(t_sent *cmd)
 
 int	execute_node(t_sent *node, char *menvp[], char *path)
 {
+	signal(SIGQUIT, SIG_DFL);
 	execve(path, node->tokens, menvp);
 	ms_error("Failed to execute command\n");
 	return (-1);

--- a/src/executecmd/executecmd_process.c
+++ b/src/executecmd/executecmd_process.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executecmd_process.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: minakim <minakim@student.42berlin.de>      +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/22 11:15:15 by minakim           #+#    #+#             */
-/*   Updated: 2023/10/22 11:30:12 by minakim          ###   ########.fr       */
+/*   Updated: 2023/11/02 13:20:15 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ static int	extract_last_path_component(t_sent *cmd)
 	char	**tmp;
 
 	if (cmd->tokens[0] == NULL)
-		return (-1);
+		return (0);
 	if (cmd->tokens[0][0] == '/')
 	{
 		tmp_size = ms_split_size(cmd->tokens[0], '/');
@@ -67,6 +67,8 @@ int	child(t_sent *cmd, t_deque *deque, int old_fd[2], int fd[2])
 	if (run_by_flag(cmd, INPUT) < 0)
 		return (-1);
 	if (run_by_flag(cmd, OUTPUT) < 0)
+		return (-1);
+	if (cmd->output_flag == PIPE_FLAG && cmd->tokens[0] == NULL)
 		return (-1);
 	fd_handler_child(deque, old_fd, fd);
 	if (is_built_in(cmd) == CHILD)

--- a/src/parsecmd/parsecmd_tokenize.c
+++ b/src/parsecmd/parsecmd_tokenize.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parsecmd_tokenize.c                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghupa <sanghupa@student.42.fr>          +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/25 23:43:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/11/01 14:30:07 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/11/02 10:55:52 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,10 +80,7 @@ static int	get_nexti(char *s)
 
 char	*ms_strndup(const char *src, int len)
 {
-	int		i;
-	int		j;
-	uint8_t	quote_s;
-	uint8_t	quote_d;
+	int		i;	
 	char	*new;
 
 	if (len == 0)
@@ -91,16 +88,7 @@ char	*ms_strndup(const char *src, int len)
 	new = (char *)ft_memalloc(len + 1);
 	if (!new)
 		return (NULL);
-	i = -1;
-	j = -1;
-	quote_s = 0;
-	quote_d = 0;
-	while (src[++i] != '\0' && i < len)
-	{
-		if (ms_strndup_helper(&src[i], i, quote_s, quote_d) == 1)
-			continue ;
-		new[++j] = src[i];
-	}
+	i = ms_strndup_helper(src, new, len);
 	while (i < len)
 		new[i++] = '\0';
 	return (new);

--- a/src/parsecmd/parsecmd_util.c
+++ b/src/parsecmd/parsecmd_util.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parsecmd_util.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: sanghupa <sanghupa@student.42.fr>          +#+  +:+       +#+        */
+/*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/01 13:03:00 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/11/01 14:29:21 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/11/02 10:55:26 by sanghupa         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -120,17 +120,30 @@ void	expand_cmd(char *cmd)
 	return ;
 }
 
-int	ms_strndup_helper(const char *src, int i, uint8_t quote_s, uint8_t quote_d)
+int	ms_strndup_helper(const char *src, char *new, int len)
 {
-	if (src[i] == '\'' && quote_d != 1)
-		quote_s ^= 1;
-	else if (src[i] == '\"' && quote_s != 1)
-		quote_d ^= 1;
-	if (!quote_d)
-		if (src[i] == '\'')
-			return (1);
-	if (!quote_s)
-		if (src[i] == '\"')
-			return (1);
-	return (0);
+	int		i;
+	int		j;
+	uint8_t	quote_s;
+	uint8_t	quote_d;
+
+	i = -1;
+	j = -1;
+	quote_s = 0;
+	quote_d = 0;
+	while (src[++i] != '\0' && i < len)
+	{
+		if (src[i] == '\'' && quote_d != 1)
+			quote_s ^= 1;
+		else if (src[i] == '\"' && quote_s != 1)
+			quote_d ^= 1;
+		if (!quote_d)
+			if (src[i] == '\'')
+				continue ;
+		if (!quote_s)
+			if (src[i] == '\"')
+				continue ;
+		new[++j] = src[i];
+	}
+	return (i);
 }


### PR DESCRIPTION
- Double and single quotes are working again.
- Can exit `cat` with `ctrl '\'`.
- Redirections are working without shut down of minishell with no token in cmd.
- `|` `||` `||||` now work fine without error.