### PR TITLE
fix: multi pipe

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42berlin.de>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/07/15 15:39:14 by sanghupa          #+#    #+#             */
-/*   Updated: 2023/11/02 10:54:20 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/11/09 19:06:11 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -318,6 +318,7 @@ typedef struct s_ctx
 	int		i;
 	int		wait_count;
 	int		cmd_count;
+	int 	last_cmd;
 }				t_ctx;
 
 t_ctx	*ms_ctx(void);
@@ -326,7 +327,8 @@ t_ctx	*ms_ctx(void);
 int		executecmd(t_deque *deque);
 int		ft_execvp(t_sent *cmd);
 void	add_wait_count(int pid);
-
+void	close_last_fd(t_sent *cmd, t_deque *deque, t_ctx *c);
+void	update_fd(t_deque *deque, t_ctx *c);
 /* src/executecmd/executecmd_process.c */
 int		run_process(t_sent *cmd, t_deque *deque);
 

--- a/src/executecmd/executecmd.c
+++ b/src/executecmd/executecmd.c
@@ -6,7 +6,7 @@
 /*   By: sanghupa <sanghupa@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/15 14:06:17 by minakim           #+#    #+#             */
-/*   Updated: 2023/11/09 17:24:08 by sanghupa         ###   ########.fr       */
+/*   Updated: 2023/11/09 19:18:52 by minakim          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,15 +20,13 @@ void	add_wait_count(int pid);
 
 int	executecmd(t_deque *deque)
 {
-	t_sent	*cmd;
-	int		bt;
-	t_ctx	*c;
-
+	t_sent		*cmd;
+	static int	bt = 0;
+	t_ctx		*c;
 	c = ms_ctx();
 	c->cmd_count = deque->size - 1;
 	while (deque->size > 0 && c->i < MAX_PIPES)
 	{
-		bt = 0;
 		cmd = deque_pop_back(deque);
 		if (cmd->next && cmd->output_flag == PIPE_FLAG)
 			pipe(c->fd);


### PR DESCRIPTION
Now it works...

```bash
미쉘> env | grep PATH | export aa=bb
```
There was a fatal error where the file descriptor was not updated correctly, causing the program to crash when mixing built-in functions (in the main process) with commands running in child processes, which has now been fixed. Since I've fixed the pipes, a lot of additional testing is needed.